### PR TITLE
feat(core): add HandoffResult types for streaming protocol handoffs

### DIFF
--- a/packages/core/src/handoff.test.ts
+++ b/packages/core/src/handoff.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from 'vitest';
+import { isHandoff, isHandoffProtocol, type HandoffResult } from './handoff.js';
+
+describe('isHandoff', () => {
+	it('returns true for valid minimal HandoffResult', () => {
+		const handoff: HandoffResult = {
+			protocol: 'websocket',
+			endpoint: 'wss://example.com/chat',
+		};
+
+		expect(isHandoff(handoff)).toBe(true);
+	});
+
+	it('returns true for HandoffResult with all fields', () => {
+		const handoff: HandoffResult = {
+			protocol: 'websocket',
+			endpoint: 'wss://example.com/chat',
+			credentials: {
+				token: 'abc123',
+				sessionId: 'session-xyz',
+				headers: { 'X-Custom': 'value' },
+			},
+			metadata: {
+				expectedLatency: 50,
+				capabilities: ['text', 'presence'],
+				expiresAt: '2025-01-15T12:00:00Z',
+				reconnect: {
+					allowed: true,
+					maxAttempts: 5,
+					backoffMs: 1000,
+				},
+				description: 'Chat connection',
+			},
+		};
+
+		expect(isHandoff(handoff)).toBe(true);
+	});
+
+	it('returns true for custom protocol types', () => {
+		const handoff: HandoffResult = {
+			protocol: 'custom-protocol',
+			endpoint: 'custom://example.com/stream',
+		};
+
+		expect(isHandoff(handoff)).toBe(true);
+	});
+
+	it('returns false for null', () => {
+		expect(isHandoff(null)).toBe(false);
+	});
+
+	it('returns false for undefined', () => {
+		expect(isHandoff(undefined)).toBe(false);
+	});
+
+	it('returns false for non-object', () => {
+		expect(isHandoff('string')).toBe(false);
+		expect(isHandoff(123)).toBe(false);
+		expect(isHandoff(true)).toBe(false);
+	});
+
+	it('returns false when protocol is missing', () => {
+		expect(
+			isHandoff({
+				endpoint: 'wss://example.com/chat',
+			})
+		).toBe(false);
+	});
+
+	it('returns false when endpoint is missing', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+			})
+		).toBe(false);
+	});
+
+	it('returns false when protocol is empty string', () => {
+		expect(
+			isHandoff({
+				protocol: '',
+				endpoint: 'wss://example.com/chat',
+			})
+		).toBe(false);
+	});
+
+	it('returns false when endpoint is empty string', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: '',
+			})
+		).toBe(false);
+	});
+
+	it('returns false when protocol is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 123,
+				endpoint: 'wss://example.com/chat',
+			})
+		).toBe(false);
+	});
+
+	it('returns false when credentials is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				credentials: 'invalid',
+			})
+		).toBe(false);
+	});
+
+	it('returns false when credentials.token is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				credentials: { token: 123 },
+			})
+		).toBe(false);
+	});
+
+	it('returns false when credentials.sessionId is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				credentials: { sessionId: 123 },
+			})
+		).toBe(false);
+	});
+
+	it('returns false when credentials.headers is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				credentials: { headers: 'invalid' },
+			})
+		).toBe(false);
+	});
+
+	it('returns false when metadata is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				metadata: 'invalid',
+			})
+		).toBe(false);
+	});
+
+	it('returns false when metadata.expectedLatency is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				metadata: { expectedLatency: 'fast' },
+			})
+		).toBe(false);
+	});
+
+	it('returns false when metadata.capabilities is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				metadata: { capabilities: 'text' },
+			})
+		).toBe(false);
+	});
+
+	it('returns false when metadata.expiresAt is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				metadata: { expiresAt: 12345 },
+			})
+		).toBe(false);
+	});
+
+	it('returns false when metadata.description is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				metadata: { description: 123 },
+			})
+		).toBe(false);
+	});
+
+	it('returns false when metadata.reconnect is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				metadata: { reconnect: 'yes' },
+			})
+		).toBe(false);
+	});
+
+	it('returns false when metadata.reconnect.allowed is missing', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				metadata: { reconnect: { maxAttempts: 5 } },
+			})
+		).toBe(false);
+	});
+
+	it('returns false when metadata.reconnect.maxAttempts is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				metadata: { reconnect: { allowed: true, maxAttempts: 'five' } },
+			})
+		).toBe(false);
+	});
+
+	it('returns false when metadata.reconnect.backoffMs is wrong type', () => {
+		expect(
+			isHandoff({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				metadata: { reconnect: { allowed: true, backoffMs: 'slow' } },
+			})
+		).toBe(false);
+	});
+
+	it('narrows type correctly', () => {
+		const maybeHandoff: unknown = {
+			protocol: 'websocket',
+			endpoint: 'wss://example.com/chat',
+		};
+
+		if (isHandoff(maybeHandoff)) {
+			// TypeScript should know maybeHandoff is HandoffResult
+			expect(maybeHandoff.protocol).toBe('websocket');
+			expect(maybeHandoff.endpoint).toBe('wss://example.com/chat');
+		} else {
+			throw new Error('Expected isHandoff to return true');
+		}
+	});
+});
+
+describe('isHandoffProtocol', () => {
+	it('returns true when protocol matches', () => {
+		const handoff: HandoffResult = {
+			protocol: 'websocket',
+			endpoint: 'wss://example.com/chat',
+		};
+
+		expect(isHandoffProtocol(handoff, 'websocket')).toBe(true);
+	});
+
+	it('returns false when protocol does not match', () => {
+		const handoff: HandoffResult = {
+			protocol: 'websocket',
+			endpoint: 'wss://example.com/chat',
+		};
+
+		expect(isHandoffProtocol(handoff, 'sse')).toBe(false);
+	});
+
+	it('works with standard protocols', () => {
+		const protocols = ['websocket', 'webrtc', 'sse', 'http-stream'] as const;
+
+		for (const protocol of protocols) {
+			const handoff: HandoffResult = {
+				protocol,
+				endpoint: 'https://example.com',
+			};
+
+			expect(isHandoffProtocol(handoff, protocol)).toBe(true);
+
+			for (const other of protocols) {
+				if (other !== protocol) {
+					expect(isHandoffProtocol(handoff, other)).toBe(false);
+				}
+			}
+		}
+	});
+
+	it('works with custom protocols', () => {
+		const handoff: HandoffResult = {
+			protocol: 'my-custom-protocol',
+			endpoint: 'custom://example.com',
+		};
+
+		expect(isHandoffProtocol(handoff, 'my-custom-protocol')).toBe(true);
+		expect(isHandoffProtocol(handoff, 'websocket')).toBe(false);
+	});
+});

--- a/packages/core/src/handoff.ts
+++ b/packages/core/src/handoff.ts
@@ -1,0 +1,229 @@
+/**
+ * @fileoverview Handoff types for AFD commands
+ *
+ * The HandoffResult interface is returned by commands that bootstrap
+ * streaming connections, allowing clients to connect to specialized
+ * protocols (WebSocket, WebRTC, SSE, etc.) for real-time communication.
+ */
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// HANDOFF TYPES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Protocol type for client dispatch.
+ *
+ * Standard protocols are provided, but custom protocols are allowed
+ * via the string union type.
+ */
+export type HandoffProtocol = 'websocket' | 'webrtc' | 'sse' | 'http-stream' | string;
+
+/**
+ * Authentication credentials for the handoff connection.
+ *
+ * @example
+ * ```typescript
+ * const credentials: HandoffCredentials = {
+ *   token: 'eyJhbGciOiJIUzI1NiIs...',
+ *   sessionId: 'session-abc123',
+ *   headers: { 'X-Custom-Header': 'value' }
+ * };
+ * ```
+ */
+export interface HandoffCredentials {
+	/** Bearer token for authentication */
+	token?: string;
+
+	/** Additional headers to include in the connection */
+	headers?: Record<string, string>;
+
+	/** Session ID for correlation */
+	sessionId?: string;
+}
+
+/**
+ * Metadata for client decision-making about the handoff.
+ *
+ * @example
+ * ```typescript
+ * const metadata: HandoffMetadata = {
+ *   expectedLatency: 50,
+ *   capabilities: ['text', 'typing-indicator', 'presence'],
+ *   expiresAt: '2025-01-15T12:00:00Z',
+ *   reconnect: {
+ *     allowed: true,
+ *     maxAttempts: 5,
+ *     backoffMs: 1000
+ *   },
+ *   description: 'Real-time chat connection'
+ * };
+ * ```
+ */
+export interface HandoffMetadata {
+	/** Expected latency in ms (hint for client) */
+	expectedLatency?: number;
+
+	/** Capabilities the channel supports */
+	capabilities?: string[];
+
+	/** When the handoff credentials expire (ISO 8601) */
+	expiresAt?: string;
+
+	/** Reconnection policy */
+	reconnect?: {
+		/** Whether reconnection is allowed */
+		allowed: boolean;
+		/** Maximum number of reconnection attempts */
+		maxAttempts?: number;
+		/** Base backoff time in milliseconds */
+		backoffMs?: number;
+	};
+
+	/** Human-readable description of the handoff */
+	description?: string;
+}
+
+/**
+ * Result returned by commands that hand off to specialized protocols.
+ *
+ * This type is used as the data payload in CommandResult<HandoffResult>.
+ * Commands returning handoffs should be marked with `handoff: true` and
+ * tagged appropriately (e.g., 'handoff', 'handoff:websocket').
+ *
+ * @example
+ * ```typescript
+ * const result = await client.call<HandoffResult>('chat.connect', { roomId });
+ * if (result.success && result.data) {
+ *   const ws = new WebSocket(result.data.endpoint);
+ *   ws.send(JSON.stringify({ auth: result.data.credentials?.token }));
+ * }
+ * ```
+ */
+export interface HandoffResult {
+	/** Protocol type for client dispatch */
+	protocol: HandoffProtocol;
+
+	/** Full URL to connect to */
+	endpoint: string;
+
+	/** Authentication credentials for the handoff */
+	credentials?: HandoffCredentials;
+
+	/** Metadata for client decision-making */
+	metadata?: HandoffMetadata;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TYPE GUARDS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Type guard to check if a value is a HandoffResult.
+ *
+ * @param value - Value to check
+ * @returns True if value is a HandoffResult
+ *
+ * @example
+ * ```typescript
+ * const result = await client.call('some.command', input);
+ * if (result.success && isHandoff(result.data)) {
+ *   // TypeScript knows result.data is HandoffResult
+ *   connect(result.data.protocol, result.data.endpoint);
+ * }
+ * ```
+ */
+export function isHandoff(value: unknown): value is HandoffResult {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	const obj = value as Record<string, unknown>;
+
+	// Required fields: protocol and endpoint
+	if (typeof obj.protocol !== 'string' || obj.protocol.length === 0) {
+		return false;
+	}
+
+	if (typeof obj.endpoint !== 'string' || obj.endpoint.length === 0) {
+		return false;
+	}
+
+	// Optional credentials validation
+	if (obj.credentials !== undefined) {
+		if (typeof obj.credentials !== 'object' || obj.credentials === null) {
+			return false;
+		}
+		const creds = obj.credentials as Record<string, unknown>;
+		if (creds.token !== undefined && typeof creds.token !== 'string') {
+			return false;
+		}
+		if (creds.sessionId !== undefined && typeof creds.sessionId !== 'string') {
+			return false;
+		}
+		if (creds.headers !== undefined) {
+			if (typeof creds.headers !== 'object' || creds.headers === null) {
+				return false;
+			}
+		}
+	}
+
+	// Optional metadata validation
+	if (obj.metadata !== undefined) {
+		if (typeof obj.metadata !== 'object' || obj.metadata === null) {
+			return false;
+		}
+		const meta = obj.metadata as Record<string, unknown>;
+		if (meta.expectedLatency !== undefined && typeof meta.expectedLatency !== 'number') {
+			return false;
+		}
+		if (meta.capabilities !== undefined && !Array.isArray(meta.capabilities)) {
+			return false;
+		}
+		if (meta.expiresAt !== undefined && typeof meta.expiresAt !== 'string') {
+			return false;
+		}
+		if (meta.description !== undefined && typeof meta.description !== 'string') {
+			return false;
+		}
+		if (meta.reconnect !== undefined) {
+			if (typeof meta.reconnect !== 'object' || meta.reconnect === null) {
+				return false;
+			}
+			const reconnect = meta.reconnect as Record<string, unknown>;
+			if (typeof reconnect.allowed !== 'boolean') {
+				return false;
+			}
+			if (reconnect.maxAttempts !== undefined && typeof reconnect.maxAttempts !== 'number') {
+				return false;
+			}
+			if (reconnect.backoffMs !== undefined && typeof reconnect.backoffMs !== 'number') {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Type guard to check if a HandoffResult uses a specific protocol.
+ *
+ * @param handoff - HandoffResult to check
+ * @param protocol - Protocol to check for
+ * @returns True if the handoff uses the specified protocol
+ *
+ * @example
+ * ```typescript
+ * if (isHandoffProtocol(handoff, 'websocket')) {
+ *   const ws = new WebSocket(handoff.endpoint);
+ * } else if (isHandoffProtocol(handoff, 'sse')) {
+ *   const eventSource = new EventSource(handoff.endpoint);
+ * }
+ * ```
+ */
+export function isHandoffProtocol(
+	handoff: HandoffResult,
+	protocol: HandoffProtocol
+): boolean {
+	return handoff.protocol === protocol;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -138,3 +138,12 @@ export {
 // Telemetry types
 export type { TelemetryEvent, TelemetrySink } from './telemetry.js';
 export { createTelemetryEvent, isTelemetryEvent } from './telemetry.js';
+
+// Handoff types
+export type {
+	HandoffResult,
+	HandoffCredentials,
+	HandoffMetadata,
+	HandoffProtocol,
+} from './handoff.js';
+export { isHandoff, isHandoffProtocol } from './handoff.js';

--- a/packages/server/src/handoff-schema.test.ts
+++ b/packages/server/src/handoff-schema.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from 'vitest';
+import {
+	HandoffResultSchema,
+	HandoffCredentialsSchema,
+	HandoffMetadataSchema,
+} from './handoff-schema.js';
+
+describe('HandoffCredentialsSchema', () => {
+	it('parses empty object', () => {
+		const result = HandoffCredentialsSchema.parse({});
+		expect(result).toEqual({});
+	});
+
+	it('parses with token', () => {
+		const result = HandoffCredentialsSchema.parse({ token: 'abc123' });
+		expect(result.token).toBe('abc123');
+	});
+
+	it('parses with sessionId', () => {
+		const result = HandoffCredentialsSchema.parse({ sessionId: 'session-xyz' });
+		expect(result.sessionId).toBe('session-xyz');
+	});
+
+	it('parses with headers', () => {
+		const result = HandoffCredentialsSchema.parse({
+			headers: { 'X-Custom': 'value', Authorization: 'Bearer token' },
+		});
+		expect(result.headers).toEqual({
+			'X-Custom': 'value',
+			Authorization: 'Bearer token',
+		});
+	});
+
+	it('parses with all fields', () => {
+		const input = {
+			token: 'abc123',
+			sessionId: 'session-xyz',
+			headers: { 'X-Custom': 'value' },
+		};
+		const result = HandoffCredentialsSchema.parse(input);
+		expect(result).toEqual(input);
+	});
+
+	it('rejects non-string token', () => {
+		expect(() => HandoffCredentialsSchema.parse({ token: 123 })).toThrow();
+	});
+
+	it('rejects non-string sessionId', () => {
+		expect(() => HandoffCredentialsSchema.parse({ sessionId: 123 })).toThrow();
+	});
+
+	it('rejects non-object headers', () => {
+		expect(() => HandoffCredentialsSchema.parse({ headers: 'invalid' })).toThrow();
+	});
+});
+
+describe('HandoffMetadataSchema', () => {
+	it('parses empty object', () => {
+		const result = HandoffMetadataSchema.parse({});
+		expect(result).toEqual({});
+	});
+
+	it('parses with expectedLatency', () => {
+		const result = HandoffMetadataSchema.parse({ expectedLatency: 50 });
+		expect(result.expectedLatency).toBe(50);
+	});
+
+	it('parses with capabilities', () => {
+		const result = HandoffMetadataSchema.parse({
+			capabilities: ['text', 'presence', 'typing'],
+		});
+		expect(result.capabilities).toEqual(['text', 'presence', 'typing']);
+	});
+
+	it('parses with expiresAt as ISO datetime', () => {
+		const result = HandoffMetadataSchema.parse({
+			expiresAt: '2025-01-15T12:00:00Z',
+		});
+		expect(result.expiresAt).toBe('2025-01-15T12:00:00Z');
+	});
+
+	it('parses with description', () => {
+		const result = HandoffMetadataSchema.parse({
+			description: 'Real-time chat connection',
+		});
+		expect(result.description).toBe('Real-time chat connection');
+	});
+
+	it('parses with reconnect policy', () => {
+		const result = HandoffMetadataSchema.parse({
+			reconnect: {
+				allowed: true,
+				maxAttempts: 5,
+				backoffMs: 1000,
+			},
+		});
+		expect(result.reconnect).toEqual({
+			allowed: true,
+			maxAttempts: 5,
+			backoffMs: 1000,
+		});
+	});
+
+	it('parses reconnect with only required field', () => {
+		const result = HandoffMetadataSchema.parse({
+			reconnect: { allowed: false },
+		});
+		expect(result.reconnect).toEqual({ allowed: false });
+	});
+
+	it('parses with all fields', () => {
+		const input = {
+			expectedLatency: 50,
+			capabilities: ['text', 'presence'],
+			expiresAt: '2025-01-15T12:00:00Z',
+			reconnect: {
+				allowed: true,
+				maxAttempts: 5,
+				backoffMs: 1000,
+			},
+			description: 'Chat connection',
+		};
+		const result = HandoffMetadataSchema.parse(input);
+		expect(result).toEqual(input);
+	});
+
+	it('rejects non-number expectedLatency', () => {
+		expect(() => HandoffMetadataSchema.parse({ expectedLatency: 'fast' })).toThrow();
+	});
+
+	it('rejects non-array capabilities', () => {
+		expect(() => HandoffMetadataSchema.parse({ capabilities: 'text' })).toThrow();
+	});
+
+	it('rejects invalid datetime for expiresAt', () => {
+		expect(() => HandoffMetadataSchema.parse({ expiresAt: 'not-a-date' })).toThrow();
+	});
+
+	it('rejects reconnect without allowed field', () => {
+		expect(() => HandoffMetadataSchema.parse({ reconnect: { maxAttempts: 5 } })).toThrow();
+	});
+
+	it('rejects non-boolean reconnect.allowed', () => {
+		expect(() => HandoffMetadataSchema.parse({ reconnect: { allowed: 'yes' } })).toThrow();
+	});
+});
+
+describe('HandoffResultSchema', () => {
+	it('parses minimal valid handoff', () => {
+		const result = HandoffResultSchema.parse({
+			protocol: 'websocket',
+			endpoint: 'wss://example.com/chat',
+		});
+
+		expect(result.protocol).toBe('websocket');
+		expect(result.endpoint).toBe('wss://example.com/chat');
+	});
+
+	it('parses with all standard protocols', () => {
+		const protocols = ['websocket', 'webrtc', 'sse', 'http-stream'];
+
+		for (const protocol of protocols) {
+			const result = HandoffResultSchema.parse({
+				protocol,
+				endpoint: 'https://example.com',
+			});
+			expect(result.protocol).toBe(protocol);
+		}
+	});
+
+	it('parses with custom protocol', () => {
+		const result = HandoffResultSchema.parse({
+			protocol: 'my-custom-protocol',
+			endpoint: 'https://example.com',
+		});
+		expect(result.protocol).toBe('my-custom-protocol');
+	});
+
+	it('parses with credentials', () => {
+		const result = HandoffResultSchema.parse({
+			protocol: 'websocket',
+			endpoint: 'wss://example.com/chat',
+			credentials: {
+				token: 'abc123',
+				sessionId: 'session-xyz',
+			},
+		});
+
+		expect(result.credentials).toEqual({
+			token: 'abc123',
+			sessionId: 'session-xyz',
+		});
+	});
+
+	it('parses with metadata', () => {
+		const result = HandoffResultSchema.parse({
+			protocol: 'websocket',
+			endpoint: 'wss://example.com/chat',
+			metadata: {
+				capabilities: ['text', 'presence'],
+				reconnect: { allowed: true },
+			},
+		});
+
+		expect(result.metadata).toEqual({
+			capabilities: ['text', 'presence'],
+			reconnect: { allowed: true },
+		});
+	});
+
+	it('parses complete handoff result', () => {
+		const input = {
+			protocol: 'websocket',
+			endpoint: 'wss://example.com/chat',
+			credentials: {
+				token: 'abc123',
+				sessionId: 'session-xyz',
+				headers: { 'X-Custom': 'value' },
+			},
+			metadata: {
+				expectedLatency: 50,
+				capabilities: ['text', 'presence'],
+				expiresAt: '2025-01-15T12:00:00Z',
+				reconnect: {
+					allowed: true,
+					maxAttempts: 5,
+					backoffMs: 1000,
+				},
+				description: 'Real-time chat connection',
+			},
+		};
+
+		const result = HandoffResultSchema.parse(input);
+		expect(result).toEqual(input);
+	});
+
+	it('rejects missing protocol', () => {
+		expect(() =>
+			HandoffResultSchema.parse({
+				endpoint: 'wss://example.com/chat',
+			})
+		).toThrow();
+	});
+
+	it('rejects missing endpoint', () => {
+		expect(() =>
+			HandoffResultSchema.parse({
+				protocol: 'websocket',
+			})
+		).toThrow();
+	});
+
+	it('rejects invalid URL for endpoint', () => {
+		expect(() =>
+			HandoffResultSchema.parse({
+				protocol: 'websocket',
+				endpoint: 'not-a-url',
+			})
+		).toThrow();
+	});
+
+	it('rejects non-string protocol', () => {
+		expect(() =>
+			HandoffResultSchema.parse({
+				protocol: 123,
+				endpoint: 'wss://example.com/chat',
+			})
+		).toThrow();
+	});
+
+	it('rejects invalid credentials', () => {
+		expect(() =>
+			HandoffResultSchema.parse({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				credentials: 'invalid',
+			})
+		).toThrow();
+	});
+
+	it('rejects invalid metadata', () => {
+		expect(() =>
+			HandoffResultSchema.parse({
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/chat',
+				metadata: 'invalid',
+			})
+		).toThrow();
+	});
+});

--- a/packages/server/src/handoff-schema.ts
+++ b/packages/server/src/handoff-schema.ts
@@ -1,0 +1,126 @@
+/**
+ * @fileoverview Zod schemas for handoff types
+ *
+ * These schemas provide runtime validation for HandoffResult and related types.
+ * Use these when defining handoff commands or validating handoff data.
+ */
+
+import { z } from 'zod';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ZOD SCHEMAS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Zod schema for HandoffCredentials.
+ *
+ * @example
+ * ```typescript
+ * const credentials = HandoffCredentialsSchema.parse({
+ *   token: 'abc123',
+ *   sessionId: 'session-xyz'
+ * });
+ * ```
+ */
+export const HandoffCredentialsSchema = z.object({
+	/** Bearer token for authentication */
+	token: z.string().optional(),
+	/** Additional headers to include */
+	headers: z.record(z.string()).optional(),
+	/** Session ID for correlation */
+	sessionId: z.string().optional(),
+});
+
+/**
+ * Zod schema for HandoffMetadata.
+ *
+ * @example
+ * ```typescript
+ * const metadata = HandoffMetadataSchema.parse({
+ *   capabilities: ['text', 'presence'],
+ *   reconnect: { allowed: true, maxAttempts: 5 }
+ * });
+ * ```
+ */
+export const HandoffMetadataSchema = z.object({
+	/** Expected latency in ms (hint for client) */
+	expectedLatency: z.number().optional(),
+	/** Capabilities the channel supports */
+	capabilities: z.array(z.string()).optional(),
+	/** When the handoff credentials expire (ISO 8601) */
+	expiresAt: z.string().datetime().optional(),
+	/** Reconnection policy */
+	reconnect: z
+		.object({
+			/** Whether reconnection is allowed */
+			allowed: z.boolean(),
+			/** Maximum number of reconnection attempts */
+			maxAttempts: z.number().optional(),
+			/** Base backoff time in milliseconds */
+			backoffMs: z.number().optional(),
+		})
+		.optional(),
+	/** Human-readable description of the handoff */
+	description: z.string().optional(),
+});
+
+/**
+ * Zod schema for HandoffResult.
+ *
+ * Use this as the outputSchema for handoff commands.
+ *
+ * @example
+ * ```typescript
+ * import { defineCommand } from '@lushly-dev/afd-server';
+ *
+ * const connectChat = defineCommand({
+ *   name: 'chat.connect',
+ *   description: 'Connect to a chat room',
+ *   handoff: true,
+ *   input: z.object({ roomId: z.string() }),
+ *   outputSchema: HandoffResultSchema,
+ *   async handler(input, ctx) {
+ *     return success({
+ *       protocol: 'websocket',
+ *       endpoint: `wss://chat.example.com/rooms/${input.roomId}`,
+ *       credentials: { token: ctx.session.token }
+ *     });
+ *   }
+ * });
+ * ```
+ */
+export const HandoffResultSchema = z.object({
+	/** Protocol type for client dispatch */
+	protocol: z.string(),
+	/** Full URL to connect to */
+	endpoint: z.string().url(),
+	/** Authentication credentials for the handoff */
+	credentials: HandoffCredentialsSchema.optional(),
+	/** Metadata for client decision-making */
+	metadata: HandoffMetadataSchema.optional(),
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// INFERRED TYPES (for type-safe usage)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Inferred type from HandoffCredentialsSchema.
+ * Matches the HandoffCredentials interface in @lushly-dev/afd-core.
+ */
+export type HandoffCredentialsInput = z.input<typeof HandoffCredentialsSchema>;
+export type HandoffCredentialsOutput = z.output<typeof HandoffCredentialsSchema>;
+
+/**
+ * Inferred type from HandoffMetadataSchema.
+ * Matches the HandoffMetadata interface in @lushly-dev/afd-core.
+ */
+export type HandoffMetadataInput = z.input<typeof HandoffMetadataSchema>;
+export type HandoffMetadataOutput = z.output<typeof HandoffMetadataSchema>;
+
+/**
+ * Inferred type from HandoffResultSchema.
+ * Matches the HandoffResult interface in @lushly-dev/afd-core.
+ */
+export type HandoffResultInput = z.input<typeof HandoffResultSchema>;
+export type HandoffResultOutput = z.output<typeof HandoffResultSchema>;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -115,3 +115,25 @@ export {
 	createAfdDocsCommand,
 	createAfdSchemaCommand,
 } from './bootstrap/index.js';
+
+// Handoff schemas
+export {
+	HandoffResultSchema,
+	HandoffCredentialsSchema,
+	HandoffMetadataSchema,
+	type HandoffCredentialsInput,
+	type HandoffCredentialsOutput,
+	type HandoffMetadataInput,
+	type HandoffMetadataOutput,
+	type HandoffResultInput,
+	type HandoffResultOutput,
+} from './handoff-schema.js';
+
+// Re-export handoff types from core for convenience
+export type {
+	HandoffResult,
+	HandoffCredentials,
+	HandoffMetadata,
+	HandoffProtocol,
+} from '@lushly-dev/afd-core';
+export { isHandoff, isHandoffProtocol } from '@lushly-dev/afd-core';


### PR DESCRIPTION
## Summary

- Add `HandoffResult`, `HandoffCredentials`, `HandoffMetadata` interfaces to `@afd/core`
- Add `HandoffProtocol` type for protocol discrimination  
- Add `isHandoff()` and `isHandoffProtocol()` type guards
- Add Zod schemas (`HandoffResultSchema`, `HandoffCredentialsSchema`, `HandoffMetadataSchema`) in `@afd/server`
- Include comprehensive tests for both type guards and Zod schemas

## Test plan

- [x] Core package builds successfully
- [x] Server package builds successfully
- [x] All 29 handoff type guard tests pass in core
- [x] All 33 handoff schema tests pass in server
- [x] `import { HandoffResult, isHandoff } from '@afd/core'` works
- [x] `import { HandoffResultSchema } from '@afd/server'` works

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)