### PR TITLE
feat(client): add protocol handlers and utilities for handoff connections

### DIFF
--- a/packages/client/src/direct.ts
+++ b/packages/client/src/direct.ts
@@ -32,9 +32,17 @@ import type {
 	McpRequest,
 	McpResponse,
 	McpTool,
+	HandoffResult,
 } from '@lushly-dev/afd-core';
-import { failure, validationError } from '@lushly-dev/afd-core';
+import { failure, validationError, isHandoff } from '@lushly-dev/afd-core';
 import type { Transport } from './transport.js';
+import type {
+	HandoffConnection,
+	HandoffConnectionOptions,
+	ReconnectingHandoffConnection,
+	ReconnectionOptions,
+} from './handoff.js';
+import { connectHandoff, createReconnectingHandoff } from './handoff.js';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // UNKNOWN TOOL ERROR TYPES
@@ -707,6 +715,35 @@ export class DirectClient {
 	 */
 	getSource(): string | undefined {
 		return this.options.source;
+	}
+
+	/**
+	 * Connect to a handoff endpoint using the appropriate protocol handler.
+	 *
+	 * @param handoff - The handoff result from a command
+	 * @param options - Connection options and callbacks
+	 * @returns A promise that resolves to a HandoffConnection
+	 * @throws Error if no handler is registered for the protocol
+	 */
+	async connectHandoff(
+		handoff: HandoffResult,
+		options: HandoffConnectionOptions = {}
+	): Promise<HandoffConnection> {
+		return connectHandoff(handoff, options);
+	}
+
+	/**
+	 * Create a reconnecting handoff connection with automatic retry logic.
+	 *
+	 * @param handoff - The initial handoff result
+	 * @param options - Reconnection options and callbacks
+	 * @returns A promise that resolves to a ReconnectingHandoffConnection
+	 */
+	async createReconnectingHandoff(
+		handoff: HandoffResult,
+		options: ReconnectionOptions = {}
+	): Promise<ReconnectingHandoffConnection> {
+		return createReconnectingHandoff(this, handoff, options);
 	}
 
 	/**

--- a/packages/client/src/handoff.test.ts
+++ b/packages/client/src/handoff.test.ts
@@ -1,0 +1,689 @@
+/**
+ * @fileoverview Tests for Handoff Protocol Handlers & Utilities
+ *
+ * These tests validate the protocol handler registry, handoff connections,
+ * and reconnection logic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	registerProtocolHandler,
+	unregisterProtocolHandler,
+	getProtocolHandler,
+	hasProtocolHandler,
+	listProtocolHandlers,
+	clearProtocolHandlers,
+	connectHandoff,
+	createReconnectingHandoff,
+	buildAuthenticatedEndpoint,
+	parseHandoffEndpoint,
+	isHandoffExpired,
+	getHandoffTTL,
+	isHandoff,
+	isHandoffProtocol,
+	type HandoffResult,
+	type HandoffConnection,
+	type ProtocolHandler,
+} from './handoff.js';
+import { DirectClient, type DirectRegistry } from './direct.js';
+import type { CommandResult, CommandContext } from '@lushly-dev/afd-core';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST FIXTURES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Create a mock handoff result for testing.
+ */
+function createMockHandoff(overrides?: Partial<HandoffResult>): HandoffResult {
+	return {
+		protocol: 'websocket',
+		endpoint: 'wss://example.com/socket',
+		credentials: {
+			token: 'test-token-123',
+			sessionId: 'session-abc',
+		},
+		metadata: {
+			expectedLatency: 50,
+			capabilities: ['text', 'typing-indicator'],
+			expiresAt: new Date(Date.now() + 3600000).toISOString(), // 1 hour from now
+			reconnect: {
+				allowed: true,
+				maxAttempts: 5,
+				backoffMs: 1000,
+			},
+			description: 'Test chat connection',
+		},
+		...overrides,
+	};
+}
+
+/**
+ * Create a mock protocol handler that simulates a connection.
+ */
+function createMockHandler(options?: {
+	simulateDelay?: number;
+	simulateError?: Error;
+	simulateDisconnect?: { code: number; reason: string; delay: number };
+}): ProtocolHandler {
+	return async (handoff, connectionOptions) => {
+		if (options?.simulateDelay) {
+			await new Promise((resolve) => setTimeout(resolve, options.simulateDelay));
+		}
+
+		if (options?.simulateError) {
+			throw options.simulateError;
+		}
+
+		let state: 'connecting' | 'connected' | 'disconnected' = 'connected';
+		let closed = false;
+
+		// Simulate connection
+		connectionOptions.onConnect?.(handoff);
+
+		// Simulate auto-disconnect if configured
+		if (options?.simulateDisconnect) {
+			setTimeout(() => {
+				if (!closed) {
+					state = 'disconnected';
+					connectionOptions.onDisconnect?.(
+						options.simulateDisconnect!.code,
+						options.simulateDisconnect!.reason
+					);
+				}
+			}, options.simulateDisconnect.delay);
+		}
+
+		return {
+			send: vi.fn((data) => {
+				if (state !== 'connected') {
+					throw new Error('Cannot send: connection closed');
+				}
+				// Simulate echo for testing
+				connectionOptions.onMessage?.({ echo: data });
+			}),
+			close: vi.fn(() => {
+				closed = true;
+				state = 'disconnected';
+				connectionOptions.onDisconnect?.(1000, 'Normal closure');
+			}),
+			get state() {
+				return state;
+			},
+			protocol: handoff.protocol,
+			endpoint: handoff.endpoint,
+		};
+	};
+}
+
+/**
+ * Mock registry for reconnection tests.
+ */
+class MockReconnectRegistry implements DirectRegistry {
+	public reconnectCalls = 0;
+	public lastReconnectArgs?: Record<string, unknown>;
+
+	async execute<T>(
+		name: string,
+		input?: unknown,
+		_context?: CommandContext
+	): Promise<CommandResult<T>> {
+		const params = (input ?? {}) as Record<string, unknown>;
+
+		if (name === 'chat-reconnect') {
+			this.reconnectCalls++;
+			this.lastReconnectArgs = params;
+
+			const newHandoff: HandoffResult = {
+				protocol: 'websocket',
+				endpoint: 'wss://example.com/socket/reconnected',
+				credentials: {
+					token: `new-token-${this.reconnectCalls}`,
+					sessionId: params.sessionId as string,
+				},
+				metadata: {
+					reconnect: {
+						allowed: true,
+						maxAttempts: 5,
+						backoffMs: 100,
+					},
+				},
+			};
+
+			return { success: true, data: newHandoff as T };
+		}
+
+		return {
+			success: false,
+			error: { code: 'COMMAND_NOT_FOUND', message: `Unknown command: ${name}` },
+		};
+	}
+
+	listCommandNames(): string[] {
+		return ['chat-reconnect'];
+	}
+
+	listCommands(): Array<{ name: string; description: string }> {
+		return [{ name: 'chat-reconnect', description: 'Reconnect to chat' }];
+	}
+
+	hasCommand(name: string): boolean {
+		return name === 'chat-reconnect';
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TESTS: Protocol Handler Registry
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('Protocol Handler Registry', () => {
+	beforeEach(() => {
+		clearProtocolHandlers();
+	});
+
+	afterEach(() => {
+		clearProtocolHandlers();
+	});
+
+	describe('registerProtocolHandler', () => {
+		it('should register a protocol handler', () => {
+			const handler = createMockHandler();
+			registerProtocolHandler('websocket', handler);
+
+			expect(hasProtocolHandler('websocket')).toBe(true);
+			expect(getProtocolHandler('websocket')).toBe(handler);
+		});
+
+		it('should override existing handler', () => {
+			const handler1 = createMockHandler();
+			const handler2 = createMockHandler();
+
+			registerProtocolHandler('websocket', handler1);
+			registerProtocolHandler('websocket', handler2);
+
+			expect(getProtocolHandler('websocket')).toBe(handler2);
+		});
+
+		it('should support multiple protocols', () => {
+			const wsHandler = createMockHandler();
+			const sseHandler = createMockHandler();
+
+			registerProtocolHandler('websocket', wsHandler);
+			registerProtocolHandler('sse', sseHandler);
+
+			expect(hasProtocolHandler('websocket')).toBe(true);
+			expect(hasProtocolHandler('sse')).toBe(true);
+			expect(listProtocolHandlers()).toEqual(['websocket', 'sse']);
+		});
+	});
+
+	describe('unregisterProtocolHandler', () => {
+		it('should remove a registered handler', () => {
+			registerProtocolHandler('websocket', createMockHandler());
+
+			const result = unregisterProtocolHandler('websocket');
+
+			expect(result).toBe(true);
+			expect(hasProtocolHandler('websocket')).toBe(false);
+		});
+
+		it('should return false for non-existent handler', () => {
+			const result = unregisterProtocolHandler('nonexistent');
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('listProtocolHandlers', () => {
+		it('should return empty array when no handlers registered', () => {
+			expect(listProtocolHandlers()).toEqual([]);
+		});
+
+		it('should return all registered protocols', () => {
+			registerProtocolHandler('websocket', createMockHandler());
+			registerProtocolHandler('sse', createMockHandler());
+			registerProtocolHandler('webrtc', createMockHandler());
+
+			expect(listProtocolHandlers()).toContain('websocket');
+			expect(listProtocolHandlers()).toContain('sse');
+			expect(listProtocolHandlers()).toContain('webrtc');
+		});
+	});
+
+	describe('clearProtocolHandlers', () => {
+		it('should remove all handlers', () => {
+			registerProtocolHandler('websocket', createMockHandler());
+			registerProtocolHandler('sse', createMockHandler());
+
+			clearProtocolHandlers();
+
+			expect(listProtocolHandlers()).toEqual([]);
+			expect(hasProtocolHandler('websocket')).toBe(false);
+			expect(hasProtocolHandler('sse')).toBe(false);
+		});
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TESTS: connectHandoff
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('connectHandoff', () => {
+	beforeEach(() => {
+		clearProtocolHandlers();
+	});
+
+	afterEach(() => {
+		clearProtocolHandlers();
+	});
+
+	it('should connect using registered protocol handler', async () => {
+		const handler = createMockHandler();
+		registerProtocolHandler('websocket', handler);
+
+		const handoff = createMockHandoff();
+		const onConnect = vi.fn();
+
+		const connection = await connectHandoff(handoff, { onConnect });
+
+		expect(connection.protocol).toBe('websocket');
+		expect(connection.endpoint).toBe('wss://example.com/socket');
+		expect(connection.state).toBe('connected');
+		expect(onConnect).toHaveBeenCalledWith(handoff);
+	});
+
+	it('should throw error for unregistered protocol', async () => {
+		const handoff = createMockHandoff({ protocol: 'unknown' });
+
+		await expect(connectHandoff(handoff)).rejects.toThrow(
+			"No protocol handler registered for 'unknown'"
+		);
+	});
+
+	it('should call onMessage when messages are received', async () => {
+		registerProtocolHandler('websocket', createMockHandler());
+
+		const handoff = createMockHandoff();
+		const onMessage = vi.fn();
+
+		const connection = await connectHandoff(handoff, { onMessage });
+
+		// Send triggers echo in mock handler
+		connection.send({ type: 'test' });
+
+		expect(onMessage).toHaveBeenCalledWith({ echo: { type: 'test' } });
+	});
+
+	it('should call onDisconnect when connection closes', async () => {
+		registerProtocolHandler('websocket', createMockHandler());
+
+		const handoff = createMockHandoff();
+		const onDisconnect = vi.fn();
+
+		const connection = await connectHandoff(handoff, { onDisconnect });
+		connection.close();
+
+		expect(onDisconnect).toHaveBeenCalledWith(1000, 'Normal closure');
+	});
+
+	it('should propagate handler errors', async () => {
+		const error = new Error('Connection failed');
+		registerProtocolHandler('websocket', createMockHandler({ simulateError: error }));
+
+		const handoff = createMockHandoff();
+
+		await expect(connectHandoff(handoff)).rejects.toThrow('Connection failed');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TESTS: createReconnectingHandoff
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('createReconnectingHandoff', () => {
+	let mockRegistry: MockReconnectRegistry;
+	let client: DirectClient;
+
+	beforeEach(() => {
+		clearProtocolHandlers();
+		mockRegistry = new MockReconnectRegistry();
+		client = new DirectClient(mockRegistry);
+
+		// Register a mock handler that tracks connections
+		registerProtocolHandler('websocket', createMockHandler());
+	});
+
+	afterEach(() => {
+		clearProtocolHandlers();
+	});
+
+	it('should establish initial connection', async () => {
+		const handoff = createMockHandoff();
+		const onConnect = vi.fn();
+
+		const connection = await createReconnectingHandoff(client, handoff, {
+			onConnect,
+		});
+
+		expect(connection.state).toBe('connected');
+		expect(connection.isReconnecting).toBe(false);
+		expect(connection.reconnectAttempt).toBe(0);
+		expect(onConnect).toHaveBeenCalled();
+	});
+
+	it('should send messages when connected', async () => {
+		const handoff = createMockHandoff();
+		const onMessage = vi.fn();
+
+		const connection = await createReconnectingHandoff(client, handoff, {
+			onMessage,
+		});
+
+		connection.send({ type: 'test', text: 'hello' });
+
+		expect(onMessage).toHaveBeenCalledWith({
+			echo: { type: 'test', text: 'hello' },
+		});
+	});
+
+	it('should close connection and stop reconnection', async () => {
+		const handoff = createMockHandoff();
+		const onDisconnect = vi.fn();
+
+		const connection = await createReconnectingHandoff(client, handoff, {
+			onDisconnect,
+		});
+
+		connection.close();
+
+		expect(connection.state).toBe('disconnected');
+		expect(onDisconnect).toHaveBeenCalled();
+	});
+
+	it('should use metadata reconnect settings', async () => {
+		const handoff = createMockHandoff({
+			metadata: {
+				reconnect: {
+					allowed: true,
+					maxAttempts: 3,
+					backoffMs: 100,
+				},
+			},
+		});
+
+		const connection = await createReconnectingHandoff(client, handoff, {});
+
+		// Connection should be established
+		expect(connection.state).toBe('connected');
+	});
+
+	it('should throw when sending on disconnected connection', async () => {
+		const handoff = createMockHandoff();
+
+		const connection = await createReconnectingHandoff(client, handoff, {});
+		connection.close();
+
+		expect(() => connection.send({ test: true })).toThrow(
+			'Cannot send: connection not in connected state'
+		);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TESTS: Type Guards
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('Type Guards', () => {
+	describe('isHandoff', () => {
+		it('should return true for valid handoff', () => {
+			const handoff = createMockHandoff();
+			expect(isHandoff(handoff)).toBe(true);
+		});
+
+		it('should return true for minimal handoff', () => {
+			const handoff = {
+				protocol: 'websocket',
+				endpoint: 'wss://example.com',
+			};
+			expect(isHandoff(handoff)).toBe(true);
+		});
+
+		it('should return false for null', () => {
+			expect(isHandoff(null)).toBe(false);
+		});
+
+		it('should return false for undefined', () => {
+			expect(isHandoff(undefined)).toBe(false);
+		});
+
+		it('should return false for non-object', () => {
+			expect(isHandoff('string')).toBe(false);
+			expect(isHandoff(123)).toBe(false);
+			expect(isHandoff(true)).toBe(false);
+		});
+
+		it('should return false for missing protocol', () => {
+			expect(isHandoff({ endpoint: 'wss://example.com' })).toBe(false);
+		});
+
+		it('should return false for missing endpoint', () => {
+			expect(isHandoff({ protocol: 'websocket' })).toBe(false);
+		});
+
+		it('should return false for empty protocol', () => {
+			expect(isHandoff({ protocol: '', endpoint: 'wss://example.com' })).toBe(false);
+		});
+
+		it('should return false for empty endpoint', () => {
+			expect(isHandoff({ protocol: 'websocket', endpoint: '' })).toBe(false);
+		});
+	});
+
+	describe('isHandoffProtocol', () => {
+		it('should return true for matching protocol', () => {
+			const handoff = createMockHandoff({ protocol: 'websocket' });
+			expect(isHandoffProtocol(handoff, 'websocket')).toBe(true);
+		});
+
+		it('should return false for non-matching protocol', () => {
+			const handoff = createMockHandoff({ protocol: 'websocket' });
+			expect(isHandoffProtocol(handoff, 'sse')).toBe(false);
+		});
+
+		it('should work with custom protocols', () => {
+			const handoff = createMockHandoff({ protocol: 'custom-protocol' });
+			expect(isHandoffProtocol(handoff, 'custom-protocol')).toBe(true);
+		});
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TESTS: Helper Functions
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('Helper Functions', () => {
+	describe('buildAuthenticatedEndpoint', () => {
+		it('should return original endpoint without credentials', () => {
+			const result = buildAuthenticatedEndpoint('wss://example.com/socket');
+			expect(result).toBe('wss://example.com/socket');
+		});
+
+		it('should return original endpoint without token', () => {
+			const result = buildAuthenticatedEndpoint('wss://example.com/socket', {});
+			expect(result).toBe('wss://example.com/socket');
+		});
+
+		it('should append token as query parameter', () => {
+			const result = buildAuthenticatedEndpoint('wss://example.com/socket', {
+				token: 'my-token-123',
+			});
+			expect(result).toBe('wss://example.com/socket?token=my-token-123');
+		});
+
+		it('should preserve existing query parameters', () => {
+			const result = buildAuthenticatedEndpoint(
+				'wss://example.com/socket?room=123',
+				{ token: 'my-token-123' }
+			);
+			expect(result).toBe('wss://example.com/socket?room=123&token=my-token-123');
+		});
+
+		it('should URL-encode token', () => {
+			const result = buildAuthenticatedEndpoint('wss://example.com/socket', {
+				token: 'token with spaces & special=chars',
+			});
+			expect(result).toContain('token=token+with+spaces');
+		});
+	});
+
+	describe('parseHandoffEndpoint', () => {
+		it('should parse WebSocket URL', () => {
+			const result = parseHandoffEndpoint('ws://example.com:8080/socket');
+			expect(result).toEqual({
+				protocol: 'ws',
+				host: 'example.com',
+				port: 8080,
+				path: '/socket',
+				secure: false,
+			});
+		});
+
+		it('should parse secure WebSocket URL', () => {
+			const result = parseHandoffEndpoint('wss://example.com/socket');
+			expect(result).toEqual({
+				protocol: 'wss',
+				host: 'example.com',
+				port: null,
+				path: '/socket',
+				secure: true,
+			});
+		});
+
+		it('should parse HTTPS URL', () => {
+			const result = parseHandoffEndpoint('https://example.com/events');
+			expect(result).toEqual({
+				protocol: 'https',
+				host: 'example.com',
+				port: null,
+				path: '/events',
+				secure: true,
+			});
+		});
+
+		it('should include query string in path', () => {
+			const result = parseHandoffEndpoint('wss://example.com/socket?room=123&user=456');
+			expect(result.path).toBe('/socket?room=123&user=456');
+		});
+	});
+
+	describe('isHandoffExpired', () => {
+		it('should return false when no expiration', () => {
+			const handoff = createMockHandoff({
+				metadata: { capabilities: ['test'] },
+			});
+			delete handoff.metadata!.expiresAt;
+
+			expect(isHandoffExpired(handoff)).toBe(false);
+		});
+
+		it('should return false when not expired', () => {
+			const handoff = createMockHandoff({
+				metadata: {
+					expiresAt: new Date(Date.now() + 3600000).toISOString(), // 1 hour from now
+				},
+			});
+
+			expect(isHandoffExpired(handoff)).toBe(false);
+		});
+
+		it('should return true when expired', () => {
+			const handoff = createMockHandoff({
+				metadata: {
+					expiresAt: new Date(Date.now() - 3600000).toISOString(), // 1 hour ago
+				},
+			});
+
+			expect(isHandoffExpired(handoff)).toBe(true);
+		});
+	});
+
+	describe('getHandoffTTL', () => {
+		it('should return null when no expiration', () => {
+			const handoff = createMockHandoff({
+				metadata: { capabilities: ['test'] },
+			});
+			delete handoff.metadata!.expiresAt;
+
+			expect(getHandoffTTL(handoff)).toBeNull();
+		});
+
+		it('should return positive TTL for future expiration', () => {
+			const expireTime = Date.now() + 3600000; // 1 hour from now
+			const handoff = createMockHandoff({
+				metadata: {
+					expiresAt: new Date(expireTime).toISOString(),
+				},
+			});
+
+			const ttl = getHandoffTTL(handoff);
+			expect(ttl).not.toBeNull();
+			// Allow some tolerance for execution time
+			expect(ttl!).toBeGreaterThan(3590000);
+			expect(ttl!).toBeLessThanOrEqual(3600000);
+		});
+
+		it('should return 0 for expired handoff', () => {
+			const handoff = createMockHandoff({
+				metadata: {
+					expiresAt: new Date(Date.now() - 3600000).toISOString(), // 1 hour ago
+				},
+			});
+
+			expect(getHandoffTTL(handoff)).toBe(0);
+		});
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TESTS: DirectClient Integration
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('DirectClient Handoff Integration', () => {
+	let mockRegistry: MockReconnectRegistry;
+	let client: DirectClient;
+
+	beforeEach(() => {
+		clearProtocolHandlers();
+		mockRegistry = new MockReconnectRegistry();
+		client = new DirectClient(mockRegistry);
+
+		registerProtocolHandler('websocket', createMockHandler());
+	});
+
+	afterEach(() => {
+		clearProtocolHandlers();
+	});
+
+	it('should connect via client.connectHandoff', async () => {
+		const handoff = createMockHandoff();
+		const onConnect = vi.fn();
+
+		const connection = await client.connectHandoff(handoff, { onConnect });
+
+		expect(connection.state).toBe('connected');
+		expect(onConnect).toHaveBeenCalled();
+	});
+
+	it('should create reconnecting handoff via client', async () => {
+		const handoff = createMockHandoff();
+		const onConnect = vi.fn();
+
+		const connection = await client.createReconnectingHandoff(handoff, {
+			onConnect,
+		});
+
+		expect(connection.state).toBe('connected');
+		expect(connection.isReconnecting).toBe(false);
+		expect(onConnect).toHaveBeenCalled();
+	});
+});

--- a/packages/client/src/handoff.ts
+++ b/packages/client/src/handoff.ts
@@ -1,0 +1,669 @@
+/**
+ * @fileoverview Handoff Protocol Handlers & Utilities
+ *
+ * This module provides utilities for handling AFD handoff results, allowing
+ * clients to connect to streaming protocols (WebSocket, SSE, WebRTC, etc.)
+ * returned by handoff commands.
+ *
+ * @example Basic usage
+ * ```typescript
+ * import { DirectClient, isHandoff, connectHandoff } from '@afd/client';
+ *
+ * const result = await client.call<HandoffResult>('chat-connect', { roomId });
+ *
+ * if (result.success && isHandoff(result.data)) {
+ *   const connection = await connectHandoff(result.data, {
+ *     onConnect: () => console.log('Connected!'),
+ *     onMessage: (msg) => console.log('Message:', msg),
+ *     onDisconnect: () => console.log('Disconnected'),
+ *   });
+ *
+ *   connection.send({ type: 'message', text: 'Hello!' });
+ * }
+ * ```
+ *
+ * @example Protocol handlers
+ * ```typescript
+ * import { registerProtocolHandler } from '@afd/client';
+ *
+ * // Register a custom WebSocket handler
+ * registerProtocolHandler('websocket', async (handoff, options) => {
+ *   const ws = new WebSocket(handoff.endpoint);
+ *   // ... setup handlers
+ *   return { send: (data) => ws.send(data), close: () => ws.close() };
+ * });
+ * ```
+ */
+
+import type {
+	HandoffResult,
+	HandoffCredentials,
+	HandoffMetadata,
+	HandoffProtocol,
+} from '@lushly-dev/afd-core';
+import { isHandoff, isHandoffProtocol } from '@lushly-dev/afd-core';
+import type { DirectClient } from './direct.js';
+
+// Re-export core types and guards for convenience
+export { isHandoff, isHandoffProtocol };
+export type { HandoffResult, HandoffCredentials, HandoffMetadata, HandoffProtocol };
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CONNECTION TYPES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Connection state for handoff connections.
+ */
+export type HandoffConnectionState =
+	| 'connecting'
+	| 'connected'
+	| 'reconnecting'
+	| 'disconnected'
+	| 'failed';
+
+/**
+ * Represents an active connection to a handoff endpoint.
+ */
+export interface HandoffConnection {
+	/**
+	 * Send data through the connection.
+	 * @param data - Data to send (will be JSON-serialized)
+	 */
+	send(data: unknown): void;
+
+	/**
+	 * Close the connection.
+	 */
+	close(): void;
+
+	/**
+	 * Get the current connection state.
+	 */
+	readonly state: HandoffConnectionState;
+
+	/**
+	 * The protocol of this connection.
+	 */
+	readonly protocol: HandoffProtocol;
+
+	/**
+	 * The endpoint URL of this connection.
+	 */
+	readonly endpoint: string;
+}
+
+/**
+ * Options for connecting to a handoff endpoint.
+ */
+export interface HandoffConnectionOptions {
+	/**
+	 * Called when the connection is established.
+	 * @param connection - The underlying connection (protocol-specific)
+	 */
+	onConnect?: (connection: unknown) => void;
+
+	/**
+	 * Called when a message is received.
+	 * @param message - Parsed message data
+	 */
+	onMessage?: (message: unknown) => void;
+
+	/**
+	 * Called when the connection is closed.
+	 * @param code - Close code (if available)
+	 * @param reason - Close reason (if available)
+	 */
+	onDisconnect?: (code?: number, reason?: string) => void;
+
+	/**
+	 * Called when an error occurs.
+	 * @param error - Error object
+	 */
+	onError?: (error: Error) => void;
+
+	/**
+	 * Called when connection state changes.
+	 * @param state - New connection state
+	 */
+	onStateChange?: (state: HandoffConnectionState) => void;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// PROTOCOL HANDLER TYPES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Handler function for a specific protocol.
+ *
+ * Protocol handlers are responsible for:
+ * 1. Establishing the connection to the endpoint
+ * 2. Handling authentication with credentials
+ * 3. Managing the connection lifecycle
+ * 4. Translating protocol-specific events to HandoffConnectionOptions callbacks
+ */
+export type ProtocolHandler = (
+	handoff: HandoffResult,
+	options: HandoffConnectionOptions
+) => Promise<HandoffConnection>;
+
+/**
+ * Internal protocol handler registry.
+ */
+const protocolHandlers = new Map<string, ProtocolHandler>();
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// PROTOCOL HANDLER REGISTRY
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Register a protocol handler for a specific protocol type.
+ *
+ * @param protocol - The protocol identifier (e.g., 'websocket', 'sse', 'webrtc')
+ * @param handler - The handler function to call when connecting to this protocol
+ *
+ * @example Browser WebSocket handler
+ * ```typescript
+ * registerProtocolHandler('websocket', async (handoff, options) => {
+ *   const ws = new WebSocket(handoff.endpoint);
+ *
+ *   ws.onopen = () => {
+ *     if (handoff.credentials?.token) {
+ *       ws.send(JSON.stringify({ type: 'auth', token: handoff.credentials.token }));
+ *     }
+ *     options.onConnect?.(ws);
+ *   };
+ *
+ *   ws.onmessage = (event) => {
+ *     options.onMessage?.(JSON.parse(event.data));
+ *   };
+ *
+ *   ws.onclose = (event) => {
+ *     options.onDisconnect?.(event.code, event.reason);
+ *   };
+ *
+ *   return {
+ *     send: (data) => ws.send(JSON.stringify(data)),
+ *     close: () => ws.close(),
+ *     state: 'connected',
+ *     protocol: handoff.protocol,
+ *     endpoint: handoff.endpoint,
+ *   };
+ * });
+ * ```
+ */
+export function registerProtocolHandler(
+	protocol: string,
+	handler: ProtocolHandler
+): void {
+	protocolHandlers.set(protocol, handler);
+}
+
+/**
+ * Unregister a protocol handler.
+ *
+ * @param protocol - The protocol identifier to unregister
+ * @returns True if a handler was removed, false if none existed
+ */
+export function unregisterProtocolHandler(protocol: string): boolean {
+	return protocolHandlers.delete(protocol);
+}
+
+/**
+ * Get a registered protocol handler.
+ *
+ * @param protocol - The protocol identifier
+ * @returns The handler function or undefined if not registered
+ */
+export function getProtocolHandler(protocol: string): ProtocolHandler | undefined {
+	return protocolHandlers.get(protocol);
+}
+
+/**
+ * Check if a protocol handler is registered.
+ *
+ * @param protocol - The protocol identifier
+ * @returns True if a handler is registered
+ */
+export function hasProtocolHandler(protocol: string): boolean {
+	return protocolHandlers.has(protocol);
+}
+
+/**
+ * List all registered protocol handlers.
+ *
+ * @returns Array of registered protocol identifiers
+ */
+export function listProtocolHandlers(): string[] {
+	return Array.from(protocolHandlers.keys());
+}
+
+/**
+ * Clear all registered protocol handlers.
+ * Useful for testing or resetting state.
+ */
+export function clearProtocolHandlers(): void {
+	protocolHandlers.clear();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// HANDOFF CONNECTION
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Connect to a handoff endpoint using the appropriate protocol handler.
+ *
+ * @param handoff - The handoff result from a command
+ * @param options - Connection options and callbacks
+ * @returns A promise that resolves to a HandoffConnection
+ * @throws Error if no handler is registered for the protocol
+ *
+ * @example
+ * ```typescript
+ * const result = await client.call<HandoffResult>('chat-connect', { roomId: 'room-123' });
+ *
+ * if (result.success && result.data) {
+ *   const connection = await connectHandoff(result.data, {
+ *     onConnect: () => console.log('Connected!'),
+ *     onMessage: (msg) => console.log('Message:', msg),
+ *     onDisconnect: (code, reason) => console.log('Disconnected:', code),
+ *   });
+ *
+ *   connection.send({ type: 'message', text: 'Hello!' });
+ *
+ *   // Later: close
+ *   connection.close();
+ * }
+ * ```
+ */
+export async function connectHandoff(
+	handoff: HandoffResult,
+	options: HandoffConnectionOptions = {}
+): Promise<HandoffConnection> {
+	const handler = protocolHandlers.get(handoff.protocol);
+
+	if (!handler) {
+		throw new Error(
+			`No protocol handler registered for '${handoff.protocol}'. ` +
+			`Available protocols: ${listProtocolHandlers().join(', ') || 'none'}. ` +
+			`Register a handler with registerProtocolHandler('${handoff.protocol}', handler).`
+		);
+	}
+
+	return handler(handoff, options);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RECONNECTION HELPER
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Options for creating a reconnecting handoff connection.
+ */
+export interface ReconnectionOptions extends HandoffConnectionOptions {
+	/**
+	 * Command to call for reconnection.
+	 * This command should return a new HandoffResult.
+	 */
+	reconnectCommand?: string;
+
+	/**
+	 * Arguments to pass to the reconnect command.
+	 */
+	reconnectArgs?: Record<string, unknown>;
+
+	/**
+	 * Session ID for reconnection (extracted from original handoff credentials).
+	 */
+	sessionId?: string;
+
+	/**
+	 * Maximum number of reconnection attempts.
+	 * @default 5
+	 */
+	maxAttempts?: number;
+
+	/**
+	 * Base backoff time in milliseconds.
+	 * @default 1000
+	 */
+	backoffMs?: number;
+
+	/**
+	 * Maximum backoff time in milliseconds.
+	 * @default 30000
+	 */
+	maxBackoffMs?: number;
+
+	/**
+	 * Called when a reconnection attempt starts.
+	 * @param attempt - Current attempt number (1-based)
+	 */
+	onReconnect?: (attempt: number) => void;
+
+	/**
+	 * Called when all reconnection attempts have failed.
+	 */
+	onReconnectFailed?: () => void;
+}
+
+/**
+ * Represents a reconnecting handoff connection with automatic retry logic.
+ */
+export interface ReconnectingHandoffConnection extends HandoffConnection {
+	/**
+	 * Current reconnection attempt number (0 if not reconnecting).
+	 */
+	readonly reconnectAttempt: number;
+
+	/**
+	 * Whether the connection is currently attempting to reconnect.
+	 */
+	readonly isReconnecting: boolean;
+
+	/**
+	 * Manually trigger a reconnection.
+	 */
+	reconnect(): Promise<void>;
+}
+
+/**
+ * Create a reconnecting handoff connection with automatic retry logic.
+ *
+ * This helper wraps a standard handoff connection and adds:
+ * - Automatic reconnection on disconnect
+ * - Exponential backoff between attempts
+ * - Session resumption via reconnect command
+ *
+ * @param client - The DirectClient to use for reconnection commands
+ * @param handoff - The initial handoff result
+ * @param options - Reconnection options and callbacks
+ * @returns A promise that resolves to a ReconnectingHandoffConnection
+ *
+ * @example
+ * ```typescript
+ * const result = await client.call<HandoffResult>('chat-connect', { roomId: 'room-123' });
+ *
+ * if (result.success && result.data) {
+ *   const connection = await createReconnectingHandoff(client, result.data, {
+ *     reconnectCommand: 'chat-reconnect',
+ *     sessionId: result.data.credentials?.sessionId,
+ *
+ *     onConnect: () => console.log('Connected'),
+ *     onReconnect: (attempt) => console.log(`Reconnecting (attempt ${attempt})`),
+ *     onReconnectFailed: () => console.log('Reconnection failed'),
+ *     onMessage: (msg) => handleMessage(msg),
+ *     onDisconnect: () => console.log('Disconnected'),
+ *   });
+ * }
+ * ```
+ */
+export async function createReconnectingHandoff(
+	client: DirectClient,
+	handoff: HandoffResult,
+	options: ReconnectionOptions = {}
+): Promise<ReconnectingHandoffConnection> {
+	const {
+		reconnectCommand,
+		reconnectArgs = {},
+		sessionId,
+		maxAttempts = options.maxAttempts ?? handoff.metadata?.reconnect?.maxAttempts ?? 5,
+		backoffMs = options.backoffMs ?? handoff.metadata?.reconnect?.backoffMs ?? 1000,
+		maxBackoffMs = 30000,
+		onReconnect,
+		onReconnectFailed,
+		onDisconnect,
+		onStateChange,
+		...connectionOptions
+	} = options;
+
+	let currentHandoff = handoff;
+	let currentConnection: HandoffConnection | null = null;
+	let reconnectAttempt = 0;
+	let isReconnecting = false;
+	let state: HandoffConnectionState = 'connecting';
+	let closed = false;
+
+	const setState = (newState: HandoffConnectionState) => {
+		state = newState;
+		onStateChange?.(newState);
+	};
+
+	const connect = async (reconnecting = false): Promise<HandoffConnection> => {
+		if (reconnecting) {
+			setState('reconnecting');
+		} else {
+			setState('connecting');
+		}
+
+		try {
+			const conn = await connectHandoff(currentHandoff, {
+				...connectionOptions,
+				onConnect: (rawConn) => {
+					setState('connected');
+					reconnectAttempt = 0;
+					isReconnecting = false;
+					connectionOptions.onConnect?.(rawConn);
+				},
+				onDisconnect: async (code, reason) => {
+					if (closed) {
+						setState('disconnected');
+						onDisconnect?.(code, reason);
+						return;
+					}
+
+					// Check if reconnection is allowed
+					const canReconnect =
+						handoff.metadata?.reconnect?.allowed !== false &&
+						reconnectAttempt < maxAttempts;
+
+					if (canReconnect) {
+						await attemptReconnect();
+					} else {
+						setState('disconnected');
+						onDisconnect?.(code, reason);
+					}
+				},
+				onError: (error) => {
+					if (connectionOptions.onError) {
+						connectionOptions.onError(error);
+					}
+				},
+			});
+
+			currentConnection = conn;
+			return conn;
+		} catch (error) {
+			if (!closed && reconnectAttempt < maxAttempts) {
+				await attemptReconnect();
+				return currentConnection!;
+			}
+			throw error;
+		}
+	};
+
+	const attemptReconnect = async (): Promise<void> => {
+		if (closed || isReconnecting) return;
+
+		isReconnecting = true;
+		reconnectAttempt++;
+
+		if (reconnectAttempt > maxAttempts) {
+			isReconnecting = false;
+			setState('failed');
+			onReconnectFailed?.();
+			return;
+		}
+
+		onReconnect?.(reconnectAttempt);
+
+		// Calculate exponential backoff with jitter
+		const delay = Math.min(
+			backoffMs * Math.pow(2, reconnectAttempt - 1) + Math.random() * 100,
+			maxBackoffMs
+		);
+
+		await sleep(delay);
+
+		if (closed) return;
+
+		// Try to get a new handoff via reconnect command
+		if (reconnectCommand) {
+			try {
+				const args = { ...reconnectArgs };
+				if (sessionId) {
+					args.sessionId = sessionId;
+				}
+
+				const result = await client.call<HandoffResult>(reconnectCommand, args);
+
+				if (result.success && result.data && isHandoff(result.data)) {
+					currentHandoff = result.data;
+				}
+			} catch {
+				// If reconnect command fails, try with original handoff
+			}
+		}
+
+		try {
+			await connect(true);
+		} catch {
+			// Reconnection failed, will be retried on next disconnect
+			if (reconnectAttempt >= maxAttempts) {
+				isReconnecting = false;
+				setState('failed');
+				onReconnectFailed?.();
+			}
+		}
+	};
+
+	// Initial connection
+	await connect(false);
+
+	const reconnectingConnection: ReconnectingHandoffConnection = {
+		get state() {
+			return state;
+		},
+		get protocol() {
+			return currentHandoff.protocol;
+		},
+		get endpoint() {
+			return currentHandoff.endpoint;
+		},
+		get reconnectAttempt() {
+			return reconnectAttempt;
+		},
+		get isReconnecting() {
+			return isReconnecting;
+		},
+
+		send(data: unknown) {
+			if (!currentConnection || state !== 'connected') {
+				throw new Error('Cannot send: connection not in connected state');
+			}
+			currentConnection.send(data);
+		},
+
+		close() {
+			closed = true;
+			isReconnecting = false;
+			currentConnection?.close();
+			setState('disconnected');
+		},
+
+		async reconnect() {
+			if (isReconnecting) return;
+			reconnectAttempt = 0;
+			await attemptReconnect();
+		},
+	};
+
+	return reconnectingConnection;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// HELPERS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Sleep for a specified number of milliseconds.
+ */
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Build a WebSocket URL with authentication token as query parameter.
+ *
+ * @param endpoint - The base WebSocket endpoint
+ * @param credentials - Optional credentials with token
+ * @returns The URL with token appended if provided
+ */
+export function buildAuthenticatedEndpoint(
+	endpoint: string,
+	credentials?: HandoffCredentials
+): string {
+	if (!credentials?.token) {
+		return endpoint;
+	}
+
+	const url = new URL(endpoint);
+	url.searchParams.set('token', credentials.token);
+	return url.toString();
+}
+
+/**
+ * Parse a handoff endpoint URL and extract connection details.
+ *
+ * @param endpoint - The endpoint URL
+ * @returns Parsed URL components
+ */
+export function parseHandoffEndpoint(endpoint: string): {
+	protocol: string;
+	host: string;
+	port: number | null;
+	path: string;
+	secure: boolean;
+} {
+	const url = new URL(endpoint);
+	const isSecure = url.protocol === 'wss:' || url.protocol === 'https:';
+
+	return {
+		protocol: url.protocol.replace(':', ''),
+		host: url.hostname,
+		port: url.port ? parseInt(url.port, 10) : null,
+		path: url.pathname + url.search,
+		secure: isSecure,
+	};
+}
+
+/**
+ * Check if handoff credentials have expired.
+ *
+ * @param handoff - The handoff result to check
+ * @returns True if credentials have expired
+ */
+export function isHandoffExpired(handoff: HandoffResult): boolean {
+	if (!handoff.metadata?.expiresAt) {
+		return false;
+	}
+
+	const expiresAt = new Date(handoff.metadata.expiresAt);
+	return expiresAt.getTime() < Date.now();
+}
+
+/**
+ * Get the time until handoff credentials expire.
+ *
+ * @param handoff - The handoff result to check
+ * @returns Milliseconds until expiration, or null if no expiration set
+ */
+export function getHandoffTTL(handoff: HandoffResult): number | null {
+	if (!handoff.metadata?.expiresAt) {
+		return null;
+	}
+
+	const expiresAt = new Date(handoff.metadata.expiresAt);
+	const ttl = expiresAt.getTime() - Date.now();
+	return ttl > 0 ? ttl : 0;
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -6,6 +6,7 @@
  * - **McpClient**: Main client class with connection management
  * - **Transports**: SSE and HTTP transports for communication
  * - **Type-safe**: Full TypeScript support with CommandResult integration
+ * - **Handoff Support**: Protocol handlers for streaming connections
  *
  * @packageDocumentation
  */
@@ -31,6 +32,39 @@ export type {
 	PendingRequest,
 	TransportType,
 } from './types.js';
+
+// Handoff protocol handlers and utilities
+export {
+	// Type guards (re-exported from core)
+	isHandoff,
+	isHandoffProtocol,
+	// Protocol handler registry
+	registerProtocolHandler,
+	unregisterProtocolHandler,
+	getProtocolHandler,
+	hasProtocolHandler,
+	listProtocolHandlers,
+	clearProtocolHandlers,
+	// Connection utilities
+	connectHandoff,
+	createReconnectingHandoff,
+	// Helper functions
+	buildAuthenticatedEndpoint,
+	parseHandoffEndpoint,
+	isHandoffExpired,
+	getHandoffTTL,
+	// Types
+	type HandoffResult,
+	type HandoffCredentials,
+	type HandoffMetadata,
+	type HandoffProtocol,
+	type HandoffConnectionState,
+	type HandoffConnection,
+	type HandoffConnectionOptions,
+	type ProtocolHandler,
+	type ReconnectionOptions,
+	type ReconnectingHandoffConnection,
+} from './handoff.js';
 
 // Re-export core types that are commonly used with client
 export type {


### PR DESCRIPTION
## Summary

- Add protocol handler registry for pluggable WebSocket, SSE, WebRTC, and custom protocol handlers
- Add `connectHandoff()` function for connecting to handoff endpoints using registered handlers
- Add `createReconnectingHandoff()` helper with automatic retry, exponential backoff, and session resumption
- Add helper functions: `buildAuthenticatedEndpoint`, `parseHandoffEndpoint`, `isHandoffExpired`, `getHandoffTTL`
- Add `connectHandoff()` and `createReconnectingHandoff()` methods to `DirectClient` class
- Re-export `isHandoff` and `isHandoffProtocol` type guards from `@afd/core`

## Test plan

- [x] Build succeeds for `@afd/client` package
- [x] All 81 tests pass (47 new handoff tests + 34 existing DirectClient tests)
- [ ] Verify type exports are accessible from package consumers
- [ ] Test with actual WebSocket handler in real application

Closes #21

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)