### PR TITLE
feat(examples): add real-time chat example with handoff pattern

### DIFF
--- a/packages/examples/chat/frontend/src/ChatRoom.tsx
+++ b/packages/examples/chat/frontend/src/ChatRoom.tsx
@@ -1,0 +1,377 @@
+/**
+ * @fileoverview ChatRoom React component example
+ *
+ * This example demonstrates how to use the handoff pattern with React:
+ * 1. Call chat-connect to get WebSocket credentials
+ * 2. Connect to the WebSocket server using the returned endpoint and token
+ * 3. Handle real-time messages and events
+ */
+
+import type { HandoffResult } from '@lushly-dev/afd-core';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface Message {
+	id: string;
+	sender: string;
+	text: string;
+	timestamp: number;
+}
+
+interface ChatRoomProps {
+	roomId: string;
+	nickname?: string;
+	/** AFD client instance for calling commands */
+	client: {
+		call: <T>(
+			command: string,
+			input: unknown
+		) => Promise<{
+			success: boolean;
+			data?: T;
+			error?: { code: string; message: string };
+		}>;
+	};
+}
+
+/**
+ * ChatRoom component - connects to a chat room via WebSocket handoff.
+ *
+ * @example
+ * ```tsx
+ * <ChatRoom
+ *   roomId="general"
+ *   nickname="User123"
+ *   client={afdClient}
+ * />
+ * ```
+ */
+export function ChatRoom({ roomId, nickname = 'Anonymous', client }: ChatRoomProps) {
+	const [messages, setMessages] = useState<Message[]>([]);
+	const [connected, setConnected] = useState(false);
+	const [connecting, setConnecting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [inputText, setInputText] = useState('');
+	const [participants, setParticipants] = useState<string[]>([]);
+	const wsRef = useRef<WebSocket | null>(null);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+
+	// Auto-scroll to bottom when new messages arrive
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+	}, [messages]);
+
+	// Connect to chat room
+	const connect = useCallback(async () => {
+		if (connecting || connected) return;
+
+		setConnecting(true);
+		setError(null);
+
+		try {
+			// Call handoff command
+			const result = await client.call<HandoffResult>('chat-connect', {
+				roomId,
+				nickname,
+			});
+
+			if (!result.success || !result.data) {
+				setError(result.error?.message ?? 'Failed to connect');
+				setConnecting(false);
+				return;
+			}
+
+			const handoff = result.data;
+
+			// Connect to WebSocket
+			const wsUrl = `${handoff.endpoint}?token=${handoff.credentials?.token}`;
+			const ws = new WebSocket(wsUrl);
+
+			ws.onopen = () => {
+				setConnected(true);
+				setConnecting(false);
+			};
+
+			ws.onmessage = (event) => {
+				try {
+					const msg = JSON.parse(event.data);
+
+					switch (msg.type) {
+						case 'welcome':
+							setParticipants(msg.participants);
+							break;
+
+						case 'message':
+							setMessages((prev) => [
+								...prev,
+								{
+									id: msg.id,
+									sender: msg.sender,
+									text: msg.text,
+									timestamp: msg.timestamp,
+								},
+							]);
+							break;
+
+						case 'user_joined':
+							setParticipants((prev) => [...prev, msg.nickname]);
+							setMessages((prev) => [
+								...prev,
+								{
+									id: `system-${Date.now()}`,
+									sender: 'System',
+									text: `${msg.nickname} joined the room`,
+									timestamp: msg.timestamp,
+								},
+							]);
+							break;
+
+						case 'user_left':
+							setParticipants((prev) => prev.filter((p) => p !== msg.nickname));
+							setMessages((prev) => [
+								...prev,
+								{
+									id: `system-${Date.now()}`,
+									sender: 'System',
+									text: `${msg.nickname} left the room`,
+									timestamp: msg.timestamp,
+								},
+							]);
+							break;
+
+						case 'error':
+							console.error('Server error:', msg.message);
+							break;
+					}
+				} catch {
+					console.error('Failed to parse message');
+				}
+			};
+
+			ws.onerror = () => {
+				setError('WebSocket connection error');
+			};
+
+			ws.onclose = () => {
+				setConnected(false);
+				setConnecting(false);
+				wsRef.current = null;
+			};
+
+			wsRef.current = ws;
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Connection failed');
+			setConnecting(false);
+		}
+	}, [roomId, nickname, client, connecting, connected]);
+
+	// Disconnect
+	const disconnect = useCallback(() => {
+		if (wsRef.current) {
+			wsRef.current.close();
+			wsRef.current = null;
+		}
+		setConnected(false);
+	}, []);
+
+	// Send message
+	const sendMessage = useCallback((text: string) => {
+		if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+			return;
+		}
+		wsRef.current.send(JSON.stringify({ type: 'message', text }));
+	}, []);
+
+	// Handle form submit
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		if (inputText.trim()) {
+			sendMessage(inputText.trim());
+			setInputText('');
+		}
+	};
+
+	// Cleanup on unmount
+	useEffect(() => {
+		return () => {
+			wsRef.current?.close();
+		};
+	}, []);
+
+	// Format timestamp
+	const formatTime = (timestamp: number) => {
+		return new Date(timestamp).toLocaleTimeString();
+	};
+
+	return (
+		<div className="chat-room">
+			<div className="chat-header">
+				<h2>Room: {roomId}</h2>
+				<div className="connection-status">
+					{connected ? (
+						<>
+							<span className="status-indicator connected" /> Connected
+							<button onClick={disconnect}>Disconnect</button>
+						</>
+					) : (
+						<>
+							<span className="status-indicator disconnected" /> Disconnected
+							<button onClick={connect} disabled={connecting}>
+								{connecting ? 'Connecting...' : 'Connect'}
+							</button>
+						</>
+					)}
+				</div>
+			</div>
+
+			{error && <div className="error-message">{error}</div>}
+
+			<div className="chat-body">
+				<div className="participants">
+					<h3>Participants ({participants.length})</h3>
+					<ul>
+						{participants.map((p) => (
+							<li key={p}>{p}</li>
+						))}
+					</ul>
+				</div>
+
+				<div className="messages">
+					{messages.map((msg) => (
+						<div key={msg.id} className={`message ${msg.sender === 'System' ? 'system' : ''}`}>
+							<span className="sender">{msg.sender}</span>
+							<span className="text">{msg.text}</span>
+							<span className="time">{formatTime(msg.timestamp)}</span>
+						</div>
+					))}
+					<div ref={messagesEndRef} />
+				</div>
+			</div>
+
+			<form className="chat-input" onSubmit={handleSubmit}>
+				<input
+					type="text"
+					value={inputText}
+					onChange={(e) => setInputText(e.target.value)}
+					placeholder="Type a message..."
+					disabled={!connected}
+				/>
+				<button type="submit" disabled={!connected || !inputText.trim()}>
+					Send
+				</button>
+			</form>
+
+			<style>{`
+				.chat-room {
+					display: flex;
+					flex-direction: column;
+					height: 100%;
+					font-family: system-ui, sans-serif;
+				}
+				.chat-header {
+					display: flex;
+					justify-content: space-between;
+					align-items: center;
+					padding: 1rem;
+					border-bottom: 1px solid #ddd;
+				}
+				.chat-header h2 {
+					margin: 0;
+				}
+				.connection-status {
+					display: flex;
+					align-items: center;
+					gap: 0.5rem;
+				}
+				.status-indicator {
+					width: 10px;
+					height: 10px;
+					border-radius: 50%;
+				}
+				.status-indicator.connected {
+					background: #22c55e;
+				}
+				.status-indicator.disconnected {
+					background: #ef4444;
+				}
+				.error-message {
+					padding: 0.5rem 1rem;
+					background: #fee2e2;
+					color: #dc2626;
+				}
+				.chat-body {
+					display: flex;
+					flex: 1;
+					overflow: hidden;
+				}
+				.participants {
+					width: 200px;
+					padding: 1rem;
+					border-right: 1px solid #ddd;
+					overflow-y: auto;
+				}
+				.participants h3 {
+					margin: 0 0 0.5rem;
+					font-size: 0.875rem;
+				}
+				.participants ul {
+					list-style: none;
+					padding: 0;
+					margin: 0;
+				}
+				.participants li {
+					padding: 0.25rem 0;
+				}
+				.messages {
+					flex: 1;
+					padding: 1rem;
+					overflow-y: auto;
+				}
+				.message {
+					margin-bottom: 0.5rem;
+					padding: 0.5rem;
+					background: #f3f4f6;
+					border-radius: 0.5rem;
+				}
+				.message.system {
+					background: #fef3c7;
+					font-style: italic;
+				}
+				.message .sender {
+					font-weight: bold;
+					margin-right: 0.5rem;
+				}
+				.message .time {
+					color: #6b7280;
+					font-size: 0.75rem;
+					margin-left: 0.5rem;
+				}
+				.chat-input {
+					display: flex;
+					gap: 0.5rem;
+					padding: 1rem;
+					border-top: 1px solid #ddd;
+				}
+				.chat-input input {
+					flex: 1;
+					padding: 0.5rem;
+					border: 1px solid #ddd;
+					border-radius: 0.25rem;
+				}
+				.chat-input button {
+					padding: 0.5rem 1rem;
+					background: #3b82f6;
+					color: white;
+					border: none;
+					border-radius: 0.25rem;
+					cursor: pointer;
+				}
+				.chat-input button:disabled {
+					background: #9ca3af;
+					cursor: not-allowed;
+				}
+			`}</style>
+		</div>
+	);
+}
+
+export default ChatRoom;

--- a/packages/examples/chat/package.json
+++ b/packages/examples/chat/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@afd/example-chat",
+	"version": "1.0.0",
+	"description": "Real-time chat example demonstrating the AFD handoff pattern for WebSocket connections",
+	"type": "module",
+	"main": "dist/server.js",
+	"scripts": {
+		"build": "tsc",
+		"start": "node dist/server.js",
+		"dev": "tsx watch src/server.ts",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@lushly-dev/afd-core": "workspace:*",
+		"@lushly-dev/afd-server": "workspace:*",
+		"ws": "^8.18.0",
+		"zod": "^3.23.0"
+	},
+	"devDependencies": {
+		"@types/ws": "^8.5.0",
+		"typescript": "^5.4.0",
+		"tsx": "^4.7.0",
+		"vitest": "^1.4.0"
+	}
+}

--- a/packages/examples/chat/src/commands/__tests__/commands.test.ts
+++ b/packages/examples/chat/src/commands/__tests__/commands.test.ts
@@ -1,0 +1,250 @@
+/**
+ * @fileoverview Tests for chat commands
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { chatService } from '../../services/chat.js';
+import { chatConnect } from '../connect.js';
+import { chatDisconnect } from '../disconnect.js';
+import { chatPoll } from '../poll.js';
+import { chatRooms } from '../rooms.js';
+import { chatSend } from '../send.js';
+import { chatStatus } from '../status.js';
+
+// Reset state before each test
+beforeEach(() => {
+	chatService.clear();
+});
+
+describe('chat-rooms', () => {
+	it('lists default rooms', async () => {
+		const result = await chatRooms.handler({}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.rooms.length).toBeGreaterThan(0);
+		expect(result.data?.rooms.some((r) => r.id === 'general')).toBe(true);
+	});
+
+	it('includes reasoning', async () => {
+		const result = await chatRooms.handler({}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.reasoning).toBeDefined();
+		expect(result.reasoning).toContain('room');
+	});
+});
+
+describe('chat-connect', () => {
+	it('returns handoff for valid room', async () => {
+		const result = await chatConnect.handler({ roomId: 'general', nickname: 'TestUser' }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.protocol).toBe('websocket');
+		expect(result.data?.endpoint).toContain('/rooms/general');
+		expect(result.data?.credentials?.token).toBeDefined();
+		expect(result.data?.credentials?.sessionId).toBeDefined();
+	});
+
+	it('includes handoff metadata', async () => {
+		const result = await chatConnect.handler({ roomId: 'general', nickname: 'TestUser' }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.metadata?.capabilities).toContain('text');
+		expect(result.data?.metadata?.capabilities).toContain('typing');
+		expect(result.data?.metadata?.reconnect?.allowed).toBe(true);
+		expect(result.data?.metadata?.expiresAt).toBeDefined();
+	});
+
+	it('includes agent hints in metadata', async () => {
+		const result = await chatConnect.handler({ roomId: 'general', nickname: 'TestUser' }, {});
+
+		expect(result.success).toBe(true);
+		const agentHints = result.metadata?.agentHints as Record<string, unknown>;
+		expect(agentHints?.fallbackCommand).toBe('chat-poll');
+		expect(agentHints?.delegateToUser).toBe(true);
+	});
+
+	it('fails for non-existent room', async () => {
+		const result = await chatConnect.handler({ roomId: 'nonexistent', nickname: 'TestUser' }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('ROOM_NOT_FOUND');
+		expect(result.error?.suggestion).toBeDefined();
+	});
+
+	it('uses default nickname when not provided', async () => {
+		const result = await chatConnect.handler({ roomId: 'general' }, {});
+
+		expect(result.success).toBe(true);
+		// Session created with 'Anonymous' nickname
+		const sessionId = result.data?.credentials?.sessionId;
+		expect(sessionId).toBeDefined();
+		const session = chatService.getSession(sessionId!);
+		expect(session?.nickname).toBe('Anonymous');
+	});
+});
+
+describe('chat-status', () => {
+	it('returns session status', async () => {
+		// First connect to create a session
+		const connectResult = await chatConnect.handler(
+			{ roomId: 'general', nickname: 'TestUser' },
+			{}
+		);
+		const sessionId = connectResult.data?.credentials?.sessionId;
+
+		const result = await chatStatus.handler({ sessionId: sessionId! }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.sessionId).toBe(sessionId);
+		expect(result.data?.roomId).toBe('general');
+		expect(result.data?.state).toBe('pending'); // Not connected via WebSocket yet
+		expect(result.data?.nickname).toBe('TestUser');
+	});
+
+	it('fails for non-existent session', async () => {
+		const result = await chatStatus.handler({ sessionId: 'nonexistent' }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('SESSION_NOT_FOUND');
+	});
+});
+
+describe('chat-disconnect', () => {
+	it('closes a session', async () => {
+		// First connect
+		const connectResult = await chatConnect.handler(
+			{ roomId: 'general', nickname: 'TestUser' },
+			{}
+		);
+		const sessionId = connectResult.data?.credentials?.sessionId;
+
+		const result = await chatDisconnect.handler({ sessionId: sessionId! }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.sessionId).toBe(sessionId);
+		expect(result.data?.closedAt).toBeDefined();
+	});
+
+	it('fails for non-existent session', async () => {
+		const result = await chatDisconnect.handler({ sessionId: 'nonexistent' }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('SESSION_NOT_FOUND');
+	});
+});
+
+describe('chat-poll', () => {
+	it('returns empty messages for empty room', async () => {
+		const result = await chatPoll.handler({ roomId: 'general', limit: 50 }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.messages).toEqual([]);
+		expect(result.data?.hasMore).toBe(false);
+	});
+
+	it('returns messages after they are sent', async () => {
+		// Send a message
+		await chatSend.handler({ roomId: 'general', text: 'Hello, world!' }, { traceId: 'test-user' });
+
+		const result = await chatPoll.handler({ roomId: 'general', limit: 50 }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.messages.length).toBe(1);
+		expect(result.data?.messages[0]?.text).toBe('Hello, world!');
+	});
+
+	it('supports pagination with since parameter', async () => {
+		// Send multiple messages
+		await chatSend.handler({ roomId: 'general', text: 'Message 1' }, {});
+		await chatSend.handler({ roomId: 'general', text: 'Message 2' }, {});
+		await chatSend.handler({ roomId: 'general', text: 'Message 3' }, {});
+
+		// Get first batch
+		const firstResult = await chatPoll.handler({ roomId: 'general', limit: 2 }, {});
+		expect(firstResult.data?.messages.length).toBe(2);
+		expect(firstResult.data?.hasMore).toBe(true);
+
+		// Get next batch
+		const secondResult = await chatPoll.handler(
+			{ roomId: 'general', since: firstResult.data?.lastMessageId, limit: 50 },
+			{}
+		);
+		expect(secondResult.data?.messages.length).toBe(1);
+		expect(secondResult.data?.messages[0]?.text).toBe('Message 3');
+	});
+
+	it('fails for non-existent room', async () => {
+		const result = await chatPoll.handler({ roomId: 'nonexistent', limit: 50 }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('ROOM_NOT_FOUND');
+	});
+
+	it('includes agent hints in metadata', async () => {
+		const result = await chatPoll.handler({ roomId: 'general', limit: 50 }, {});
+
+		expect(result.success).toBe(true);
+		const agentHints = result.metadata?.agentHints as Record<string, unknown>;
+		expect(agentHints?.pollInterval).toBe(5000);
+	});
+});
+
+describe('chat-send', () => {
+	it('sends a message', async () => {
+		const result = await chatSend.handler({ roomId: 'general', text: 'Test message' }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.messageId).toBeDefined();
+		expect(result.data?.timestamp).toBeDefined();
+	});
+
+	it('fails for non-existent room', async () => {
+		const result = await chatSend.handler({ roomId: 'nonexistent', text: 'Test' }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('ROOM_NOT_FOUND');
+	});
+
+	it('uses session nickname when provided', async () => {
+		// Create a session first
+		const connectResult = await chatConnect.handler(
+			{ roomId: 'general', nickname: 'TestUser' },
+			{}
+		);
+		const sessionId = connectResult.data?.credentials?.sessionId;
+
+		// Send with session
+		await chatSend.handler({ roomId: 'general', text: 'Hello', sessionId }, {});
+
+		// Poll to see the message
+		const pollResult = await chatPoll.handler({ roomId: 'general', limit: 50 }, {});
+		expect(pollResult.data?.messages[0]?.sender).toBe('TestUser');
+	});
+});
+
+describe('AFD Compliance', () => {
+	it('success results include reasoning', async () => {
+		const result = await chatRooms.handler({}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.reasoning).toBeDefined();
+		expect(typeof result.reasoning).toBe('string');
+	});
+
+	it('error results include suggestion', async () => {
+		const result = await chatConnect.handler({ roomId: 'nonexistent' }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.suggestion).toBeDefined();
+	});
+
+	it('handoff commands include proper metadata', async () => {
+		const result = await chatConnect.handler({ roomId: 'general' }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.protocol).toBeDefined();
+		expect(result.data?.endpoint).toBeDefined();
+		expect(result.data?.metadata).toBeDefined();
+	});
+});

--- a/packages/examples/chat/src/commands/connect.ts
+++ b/packages/examples/chat/src/commands/connect.ts
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview chat-connect command
+ *
+ * Connects to a chat room and returns a WebSocket handoff for real-time messaging.
+ */
+
+import { createError } from '@lushly-dev/afd-core';
+import type { HandoffResult } from '@lushly-dev/afd-core';
+import { defineCommand, failure, success } from '@lushly-dev/afd-server';
+import { z } from 'zod';
+import { chatService } from '../services/chat.js';
+
+const inputSchema = z.object({
+	roomId: z.string().min(1).describe('Chat room ID'),
+	nickname: z.string().min(1).max(50).optional().describe('Display name'),
+});
+
+export const chatConnect = defineCommand<typeof inputSchema, HandoffResult>({
+	name: 'chat-connect',
+	category: 'chat',
+	description: 'Connect to a chat room for real-time messaging',
+	tags: ['chat', 'handoff', 'handoff:websocket'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['ROOM_NOT_FOUND', 'ROOM_FULL'],
+
+	async handler(input, ctx) {
+		// Check room exists
+		const room = chatService.getRoom(input.roomId);
+		if (!room) {
+			return failure(
+				createError('ROOM_NOT_FOUND', `Room "${input.roomId}" does not exist`, {
+					suggestion: 'Use chat-rooms to list available rooms',
+				})
+			);
+		}
+
+		// Check room capacity
+		if (room.participants >= room.maxParticipants) {
+			return failure(
+				createError('ROOM_FULL', 'Room is at capacity', {
+					suggestion: 'Try again later or join a different room',
+				})
+			);
+		}
+
+		// Create session
+		const session = chatService.createSession({
+			roomId: input.roomId,
+			userId: ctx.traceId ?? 'anonymous',
+			nickname: input.nickname ?? 'Anonymous',
+		});
+
+		// Get WebSocket base URL from environment or use default
+		const wsBaseUrl = process.env.WS_BASE_URL ?? 'ws://localhost:3001';
+
+		return success<HandoffResult>(
+			{
+				protocol: 'websocket',
+				endpoint: `${wsBaseUrl}/rooms/${input.roomId}`,
+				credentials: {
+					token: session.token,
+					sessionId: session.id,
+				},
+				metadata: {
+					expiresAt: session.expiresAt.toISOString(),
+					capabilities: ['text', 'typing', 'presence', 'reactions'],
+					reconnect: {
+						allowed: true,
+						maxAttempts: 5,
+						backoffMs: 1000,
+					},
+					description: `Real-time chat in "${room.name}"`,
+				},
+			},
+			{
+				reasoning: `Session created for room "${room.name}". Connect to the WebSocket URL within 5 minutes.`,
+				metadata: {
+					agentHints: {
+						handoffType: 'websocket',
+						consumable: false,
+						delegateToUser: true,
+						fallbackCommand: 'chat-poll',
+					},
+				},
+			}
+		);
+	},
+});

--- a/packages/examples/chat/src/commands/disconnect.ts
+++ b/packages/examples/chat/src/commands/disconnect.ts
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview chat-disconnect command
+ *
+ * End a chat session.
+ */
+
+import { createError } from '@lushly-dev/afd-core';
+import { defineCommand, failure, success } from '@lushly-dev/afd-server';
+import { z } from 'zod';
+import { chatService } from '../services/chat.js';
+
+const inputSchema = z.object({
+	sessionId: z.string().min(1).describe('Session ID to disconnect'),
+	reason: z.string().optional().describe('Optional disconnect reason'),
+});
+
+interface DisconnectResult {
+	sessionId: string;
+	closedAt: string;
+	duration?: number;
+	messagesSent: number;
+}
+
+export const chatDisconnect = defineCommand<typeof inputSchema, DisconnectResult>({
+	name: 'chat-disconnect',
+	category: 'chat',
+	description: 'End a chat session',
+	tags: ['chat', 'write', 'safe'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['SESSION_NOT_FOUND', 'FORBIDDEN'],
+
+	async handler(input) {
+		const session = chatService.getSession(input.sessionId);
+
+		if (!session) {
+			return failure(
+				createError('SESSION_NOT_FOUND', 'Session does not exist', {
+					suggestion: 'The session may have already been closed',
+				})
+			);
+		}
+
+		const closedSession = chatService.endSession(session.id, {
+			reason: input.reason,
+		});
+
+		if (!closedSession) {
+			return failure(createError('SESSION_NOT_FOUND', 'Failed to close session'));
+		}
+
+		return success<DisconnectResult>(
+			{
+				sessionId: closedSession.id,
+				closedAt: closedSession.closedAt?.toISOString() ?? new Date().toISOString(),
+				duration: closedSession.duration,
+				messagesSent: closedSession.messagesSent,
+			},
+			{
+				reasoning: 'Session closed. Any active WebSocket connection will be terminated.',
+			}
+		);
+	},
+});

--- a/packages/examples/chat/src/commands/index.ts
+++ b/packages/examples/chat/src/commands/index.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Export all chat commands
+ */
+
+export { chatConnect } from './connect.js';
+export { chatStatus } from './status.js';
+export { chatDisconnect } from './disconnect.js';
+export { chatPoll } from './poll.js';
+export { chatRooms } from './rooms.js';
+export { chatSend } from './send.js';
+
+import type { ZodCommandDefinition } from '@lushly-dev/afd-server';
+// Re-export as array for convenience
+import { chatConnect } from './connect.js';
+import { chatDisconnect } from './disconnect.js';
+import { chatPoll } from './poll.js';
+import { chatRooms } from './rooms.js';
+import { chatSend } from './send.js';
+import { chatStatus } from './status.js';
+
+/**
+ * All chat commands as an array.
+ */
+export const allCommands = [
+	chatConnect,
+	chatStatus,
+	chatDisconnect,
+	chatPoll,
+	chatRooms,
+	chatSend,
+] as unknown as ZodCommandDefinition[];

--- a/packages/examples/chat/src/commands/poll.ts
+++ b/packages/examples/chat/src/commands/poll.ts
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview chat-poll command
+ *
+ * Poll for new messages - a fallback for agents that cannot use WebSocket.
+ */
+
+import { createError } from '@lushly-dev/afd-core';
+import { defineCommand, failure, success } from '@lushly-dev/afd-server';
+import { z } from 'zod';
+import { chatService } from '../services/chat.js';
+
+const inputSchema = z.object({
+	roomId: z.string().min(1).describe('Room ID to poll messages from'),
+	since: z.string().optional().describe('Last message ID seen'),
+	limit: z.number().min(1).max(100).optional().default(50).describe('Maximum messages to return'),
+});
+
+interface PollMessage {
+	id: string;
+	sender: string;
+	text: string;
+	timestamp: string;
+}
+
+interface PollResult {
+	roomId: string;
+	messages: PollMessage[];
+	hasMore: boolean;
+	lastMessageId?: string;
+}
+
+export const chatPoll = defineCommand<typeof inputSchema, PollResult>({
+	name: 'chat-poll',
+	category: 'chat',
+	description: 'Poll for new messages (fallback for agents without WebSocket)',
+	tags: ['chat', 'read', 'agent-friendly'],
+	mutation: false,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['ROOM_NOT_FOUND'],
+
+	async handler(input) {
+		const room = chatService.getRoom(input.roomId);
+		if (!room) {
+			return failure(
+				createError('ROOM_NOT_FOUND', 'Room does not exist', {
+					suggestion: 'Use chat-rooms to list available rooms',
+				})
+			);
+		}
+
+		const limit = input.limit ?? 50;
+		const messages = chatService.getMessages({
+			roomId: input.roomId,
+			after: input.since,
+			limit: limit,
+		});
+
+		const lastMessage = messages[messages.length - 1];
+
+		return success<PollResult>(
+			{
+				roomId: input.roomId,
+				messages: messages.map((m) => ({
+					id: m.id,
+					sender: m.nickname,
+					text: m.text,
+					timestamp: m.createdAt.toISOString(),
+				})),
+				hasMore: messages.length === limit,
+				lastMessageId: lastMessage?.id,
+			},
+			{
+				reasoning:
+					messages.length > 0 ? `Retrieved ${messages.length} messages` : 'No new messages',
+				metadata: {
+					agentHints: {
+						nextAction:
+							messages.length > 0
+								? `Process ${messages.length} messages. Poll again with since="${lastMessage?.id}"`
+								: 'No new messages. Wait 3-5 seconds and poll again.',
+						pollInterval: 5000,
+					},
+				},
+			}
+		);
+	},
+});

--- a/packages/examples/chat/src/commands/rooms.ts
+++ b/packages/examples/chat/src/commands/rooms.ts
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview chat-rooms command
+ *
+ * List available chat rooms.
+ */
+
+import { defineCommand, success } from '@lushly-dev/afd-server';
+import { z } from 'zod';
+import { chatService } from '../services/chat.js';
+
+const inputSchema = z.object({});
+
+interface RoomInfo {
+	id: string;
+	name: string;
+	description?: string;
+	participants: number;
+	maxParticipants: number;
+	available: boolean;
+}
+
+interface RoomsResult {
+	rooms: RoomInfo[];
+	total: number;
+}
+
+export const chatRooms = defineCommand<typeof inputSchema, RoomsResult>({
+	name: 'chat-rooms',
+	category: 'chat',
+	description: 'List available chat rooms',
+	tags: ['chat', 'read'],
+	mutation: false,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: [],
+
+	async handler() {
+		const rooms = chatService.getRooms();
+
+		return success<RoomsResult>(
+			{
+				rooms: rooms.map((r) => ({
+					id: r.id,
+					name: r.name,
+					description: r.description,
+					participants: r.participants,
+					maxParticipants: r.maxParticipants,
+					available: r.participants < r.maxParticipants,
+				})),
+				total: rooms.length,
+			},
+			{
+				reasoning: `Found ${rooms.length} available chat rooms`,
+			}
+		);
+	},
+});

--- a/packages/examples/chat/src/commands/send.ts
+++ b/packages/examples/chat/src/commands/send.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview chat-send command
+ *
+ * Send a message to a chat room (for agents using polling).
+ */
+
+import { createError } from '@lushly-dev/afd-core';
+import { defineCommand, failure, success } from '@lushly-dev/afd-server';
+import { z } from 'zod';
+import { chatService } from '../services/chat.js';
+
+const inputSchema = z.object({
+	roomId: z.string().min(1).describe('Room ID to send message to'),
+	text: z.string().min(1).max(2000).describe('Message text'),
+	sessionId: z.string().optional().describe('Optional session ID for attribution'),
+});
+
+interface SendResult {
+	messageId: string;
+	timestamp: string;
+}
+
+export const chatSend = defineCommand<typeof inputSchema, SendResult>({
+	name: 'chat-send',
+	category: 'chat',
+	description: 'Send a message to a chat room',
+	tags: ['chat', 'write', 'agent-friendly'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['ROOM_NOT_FOUND', 'SESSION_NOT_FOUND'],
+
+	async handler(input, ctx) {
+		const room = chatService.getRoom(input.roomId);
+		if (!room) {
+			return failure(
+				createError('ROOM_NOT_FOUND', 'Room does not exist', {
+					suggestion: 'Use chat-rooms to list available rooms',
+				})
+			);
+		}
+
+		// Get nickname from session or use default
+		let nickname = 'Agent';
+		let sessionId = input.sessionId;
+
+		if (sessionId) {
+			const session = chatService.getSession(sessionId);
+			if (session) {
+				nickname = session.nickname;
+			}
+		} else {
+			// Create an anonymous session for this message
+			const session = chatService.createSession({
+				roomId: input.roomId,
+				userId: ctx.traceId ?? 'agent',
+				nickname: 'Agent',
+			});
+			sessionId = session.id;
+		}
+
+		const message = chatService.saveMessage({
+			roomId: input.roomId,
+			sessionId: sessionId,
+			nickname: nickname,
+			text: input.text,
+		});
+
+		return success<SendResult>(
+			{
+				messageId: message.id,
+				timestamp: message.createdAt.toISOString(),
+			},
+			{
+				reasoning: `Message sent to room "${room.name}"`,
+			}
+		);
+	},
+});

--- a/packages/examples/chat/src/commands/status.ts
+++ b/packages/examples/chat/src/commands/status.ts
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview chat-status command
+ *
+ * Get the status of a chat session.
+ */
+
+import { createError } from '@lushly-dev/afd-core';
+import { defineCommand, failure, success } from '@lushly-dev/afd-server';
+import { z } from 'zod';
+import { chatService } from '../services/chat.js';
+
+const inputSchema = z.object({
+	sessionId: z.string().min(1).describe('Session ID to check'),
+});
+
+interface StatusResult {
+	sessionId: string;
+	roomId: string;
+	state: string;
+	nickname: string;
+	connectedAt?: string;
+	lastActivity?: string;
+	metrics: {
+		messagesSent: number;
+		messagesReceived: number;
+	};
+}
+
+export const chatStatus = defineCommand<typeof inputSchema, StatusResult>({
+	name: 'chat-status',
+	category: 'chat',
+	description: 'Get status of a chat session',
+	tags: ['chat', 'read'],
+	mutation: false,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['SESSION_NOT_FOUND', 'FORBIDDEN'],
+
+	async handler(input) {
+		const session = chatService.getSession(input.sessionId);
+
+		if (!session) {
+			return failure(
+				createError('SESSION_NOT_FOUND', 'Session does not exist', {
+					suggestion: 'Use chat-connect to create a new session',
+				})
+			);
+		}
+
+		return success<StatusResult>(
+			{
+				sessionId: session.id,
+				roomId: session.roomId,
+				state: session.state,
+				nickname: session.nickname,
+				connectedAt: session.connectedAt?.toISOString(),
+				lastActivity: session.lastActivity?.toISOString(),
+				metrics: {
+					messagesSent: session.messagesSent,
+					messagesReceived: session.messagesReceived,
+				},
+			},
+			{
+				reasoning: `Session "${session.id}" is ${session.state}`,
+			}
+		);
+	},
+});

--- a/packages/examples/chat/src/index.ts
+++ b/packages/examples/chat/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview Chat example - demonstrating the AFD handoff pattern
+ *
+ * This example shows how to implement real-time chat using the handoff pattern:
+ * 1. Commands handle session management and return WebSocket handoff credentials
+ * 2. WebSocket server handles real-time message delivery
+ * 3. Polling commands provide a fallback for agents that cannot use WebSocket
+ */
+
+export * from './commands/index.js';
+export * from './services/chat.js';
+export * from './types.js';
+export { createWebSocketServer } from './ws-server.js';

--- a/packages/examples/chat/src/server.ts
+++ b/packages/examples/chat/src/server.ts
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview Chat app MCP server entry point
+ *
+ * This file creates and starts an MCP server exposing all chat commands,
+ * along with a WebSocket server for real-time messaging.
+ *
+ * Usage:
+ *   node dist/server.js
+ *
+ * Then connect with the AFD CLI:
+ *   afd connect http://localhost:3100/sse
+ *   afd call chat-rooms
+ *   afd call chat-connect '{"roomId": "general", "nickname": "CLI-User"}'
+ */
+
+import {
+	createLoggingMiddleware,
+	createMcpServer,
+	getBootstrapCommands,
+} from '@lushly-dev/afd-server';
+import type { ZodCommandDefinition } from '@lushly-dev/afd-server';
+import { allCommands } from './commands/index.js';
+import { createWebSocketServer } from './ws-server.js';
+
+// Configuration from environment
+const PORT = Number.parseInt(process.env.PORT ?? '3100', 10);
+const WS_PORT = Number.parseInt(process.env.WS_PORT ?? '3001', 10);
+const HOST = process.env.HOST ?? 'localhost';
+const LOG_LEVEL = process.env.LOG_LEVEL ?? 'info';
+const TRANSPORT = (process.env.TRANSPORT ?? 'auto') as 'auto' | 'http' | 'stdio';
+const DEV_MODE = process.env.NODE_ENV === 'development';
+
+/**
+ * Create and configure the MCP server.
+ */
+function createServer() {
+	// Combine app commands with bootstrap tools (afd-help, afd-docs, afd-schema)
+	const bootstrapCommands = getBootstrapCommands(
+		() => allCommands as unknown as import('@lushly-dev/afd-core').CommandDefinition[]
+	) as unknown as ZodCommandDefinition[];
+	const allServerCommands = [...allCommands, ...bootstrapCommands];
+
+	return createMcpServer({
+		name: 'chat-app',
+		version: '1.0.0',
+		commands: allServerCommands,
+		port: PORT,
+		host: HOST,
+		devMode: DEV_MODE,
+		transport: TRANSPORT,
+		cors: true,
+
+		middleware:
+			DEV_MODE || LOG_LEVEL === 'debug'
+				? [createLoggingMiddleware({ logInput: true, logResult: true })]
+				: [createLoggingMiddleware()],
+
+		onCommand(command, input, result) {
+			if (LOG_LEVEL === 'debug') {
+				console.error(`[Command] ${command}:`, { input, result });
+			}
+		},
+
+		onError(error) {
+			console.error('[Error]', error);
+		},
+	});
+}
+
+/**
+ * Main entry point.
+ */
+async function main() {
+	const server = createServer();
+	const isInteractive = process.stdin.isTTY;
+
+	if (isInteractive) {
+		console.error('Starting Chat App...');
+		console.error(`  MCP Server: todo-app v1.0.0`);
+		console.error(
+			`  Mode: ${
+				DEV_MODE
+					? '🔧 DEVELOPMENT (verbose errors, permissive CORS)'
+					: '🔒 PRODUCTION (secure defaults)'
+			}`
+		);
+		console.error(`  Commands: ${allCommands.length}`);
+		console.error('');
+	}
+
+	// Start MCP server
+	await server.start();
+
+	// Start WebSocket server
+	const wss = createWebSocketServer(WS_PORT);
+
+	if (isInteractive) {
+		console.error(`MCP Server running at ${server.getUrl()}`);
+		console.error(`WebSocket Server running at ws://${HOST}:${WS_PORT}`);
+		console.error('');
+		console.error('Connect with the AFD CLI:');
+		console.error(`  afd connect ${server.getUrl()}/sse`);
+		console.error('');
+		console.error('Example usage:');
+		console.error('  afd call chat-rooms');
+		console.error(`  afd call chat-connect '{"roomId": "general", "nickname": "CLI-User"}'`);
+		console.error('');
+		console.error('Available commands:');
+		for (const cmd of server.getCommands()) {
+			console.error(`  - ${cmd.name}: ${cmd.description}`);
+		}
+		console.error('');
+		console.error('Press Ctrl+C to stop.');
+	}
+
+	// Handle shutdown
+	const shutdown = async () => {
+		console.error('\nShutting down...');
+		wss.close();
+		await server.stop();
+		process.exit(0);
+	};
+
+	process.on('SIGINT', shutdown);
+	process.on('SIGTERM', shutdown);
+}
+
+// Run
+main().catch((error) => {
+	console.error('Failed to start server:', error);
+	process.exit(1);
+});

--- a/packages/examples/chat/src/services/chat.ts
+++ b/packages/examples/chat/src/services/chat.ts
@@ -1,0 +1,281 @@
+/**
+ * @fileoverview Chat service for managing rooms, sessions, and messages
+ */
+
+import type { Message, Room, Session } from '../types.js';
+
+/**
+ * Generate a simple unique ID.
+ */
+function generateId(): string {
+	return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/**
+ * Generate a session token.
+ */
+function generateToken(): string {
+	return `tok_${generateId()}_${Math.random().toString(36).substring(2, 15)}`;
+}
+
+/**
+ * In-memory chat service.
+ *
+ * This is a simple implementation for demonstration purposes.
+ * A production system would use a database and Redis for pub/sub.
+ */
+class ChatService {
+	private rooms = new Map<string, Room>();
+	private sessions = new Map<string, Session>();
+	private messages: Message[] = [];
+
+	constructor() {
+		// Initialize with default rooms
+		this.initializeDefaultRooms();
+	}
+
+	private initializeDefaultRooms(): void {
+		const defaultRooms: Omit<Room, 'createdAt'>[] = [
+			{
+				id: 'general',
+				name: 'General',
+				description: 'General discussion room',
+				participants: 0,
+				maxParticipants: 100,
+			},
+			{
+				id: 'random',
+				name: 'Random',
+				description: 'Random chat and off-topic discussions',
+				participants: 0,
+				maxParticipants: 50,
+			},
+			{
+				id: 'help',
+				name: 'Help',
+				description: 'Get help with AFD and related topics',
+				participants: 0,
+				maxParticipants: 25,
+			},
+		];
+
+		for (const room of defaultRooms) {
+			this.rooms.set(room.id, {
+				...room,
+				createdAt: new Date(),
+			});
+		}
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// ROOM OPERATIONS
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Get a room by ID.
+	 */
+	getRoom(roomId: string): Room | undefined {
+		return this.rooms.get(roomId);
+	}
+
+	/**
+	 * Get all rooms.
+	 */
+	getRooms(): Room[] {
+		return Array.from(this.rooms.values());
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// SESSION OPERATIONS
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Create a new chat session.
+	 */
+	createSession(options: {
+		roomId: string;
+		userId: string;
+		nickname: string;
+	}): Session {
+		const session: Session = {
+			id: `sess_${generateId()}`,
+			roomId: options.roomId,
+			userId: options.userId,
+			nickname: options.nickname,
+			token: generateToken(),
+			state: 'pending',
+			expiresAt: new Date(Date.now() + 5 * 60 * 1000), // 5 minutes to connect
+			messagesSent: 0,
+			messagesReceived: 0,
+		};
+
+		this.sessions.set(session.id, session);
+		return session;
+	}
+
+	/**
+	 * Get a session by ID.
+	 */
+	getSession(sessionId: string): Session | undefined {
+		return this.sessions.get(sessionId);
+	}
+
+	/**
+	 * Find a session by token.
+	 */
+	getSessionByToken(token: string): Session | undefined {
+		for (const session of this.sessions.values()) {
+			if (session.token === token) {
+				return session;
+			}
+		}
+		return undefined;
+	}
+
+	/**
+	 * Mark a session as connected.
+	 */
+	markConnected(sessionId: string): Session | undefined {
+		const session = this.sessions.get(sessionId);
+		if (!session) return undefined;
+
+		const room = this.rooms.get(session.roomId);
+		if (room) {
+			room.participants++;
+		}
+
+		session.state = 'connected';
+		session.connectedAt = new Date();
+		session.lastActivity = new Date();
+		return session;
+	}
+
+	/**
+	 * Mark a session as disconnected.
+	 */
+	markDisconnected(sessionId: string): Session | undefined {
+		const session = this.sessions.get(sessionId);
+		if (!session) return undefined;
+
+		const room = this.rooms.get(session.roomId);
+		if (room && room.participants > 0) {
+			room.participants--;
+		}
+
+		session.state = 'disconnected';
+		session.closedAt = new Date();
+		if (session.connectedAt) {
+			session.duration = Math.floor(
+				(session.closedAt.getTime() - session.connectedAt.getTime()) / 1000
+			);
+		}
+		return session;
+	}
+
+	/**
+	 * End a session explicitly.
+	 */
+	endSession(sessionId: string, options?: { reason?: string }): Session | undefined {
+		return this.markDisconnected(sessionId);
+	}
+
+	/**
+	 * Update session activity.
+	 */
+	updateActivity(sessionId: string): void {
+		const session = this.sessions.get(sessionId);
+		if (session) {
+			session.lastActivity = new Date();
+		}
+	}
+
+	/**
+	 * Increment messages sent counter.
+	 */
+	incrementMessagesSent(sessionId: string): void {
+		const session = this.sessions.get(sessionId);
+		if (session) {
+			session.messagesSent++;
+			session.lastActivity = new Date();
+		}
+	}
+
+	/**
+	 * Increment messages received counter.
+	 */
+	incrementMessagesReceived(sessionId: string): void {
+		const session = this.sessions.get(sessionId);
+		if (session) {
+			session.messagesReceived++;
+		}
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// MESSAGE OPERATIONS
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Save a message.
+	 */
+	saveMessage(options: {
+		roomId: string;
+		sessionId: string;
+		nickname: string;
+		text: string;
+	}): Message {
+		const message: Message = {
+			id: `msg_${generateId()}`,
+			roomId: options.roomId,
+			sessionId: options.sessionId,
+			nickname: options.nickname,
+			text: options.text,
+			createdAt: new Date(),
+		};
+
+		this.messages.push(message);
+		this.incrementMessagesSent(options.sessionId);
+
+		return message;
+	}
+
+	/**
+	 * Get messages for a room.
+	 */
+	getMessages(options: {
+		roomId: string;
+		after?: string;
+		limit?: number;
+	}): Message[] {
+		const limit = options.limit ?? 50;
+
+		let filtered = this.messages.filter((m) => m.roomId === options.roomId);
+
+		if (options.after) {
+			const afterIndex = filtered.findIndex((m) => m.id === options.after);
+			if (afterIndex !== -1) {
+				filtered = filtered.slice(afterIndex + 1);
+			}
+		}
+
+		return filtered.slice(0, limit);
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════════
+	// UTILITY
+	// ═══════════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Clear all data (for testing).
+	 */
+	clear(): void {
+		this.rooms.clear();
+		this.sessions.clear();
+		this.messages = [];
+		this.initializeDefaultRooms();
+	}
+}
+
+/**
+ * Singleton chat service instance.
+ */
+export const chatService = new ChatService();

--- a/packages/examples/chat/src/types.ts
+++ b/packages/examples/chat/src/types.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Type definitions for the chat example
+ */
+
+/**
+ * Chat room entity.
+ */
+export interface Room {
+	id: string;
+	name: string;
+	description?: string;
+	participants: number;
+	maxParticipants: number;
+	createdAt: Date;
+}
+
+/**
+ * Session states.
+ */
+export type SessionState = 'pending' | 'connected' | 'disconnected';
+
+/**
+ * Chat session entity representing a user's connection to a room.
+ */
+export interface Session {
+	id: string;
+	roomId: string;
+	userId: string;
+	nickname: string;
+	token: string;
+	state: SessionState;
+	expiresAt: Date;
+	connectedAt?: Date;
+	lastActivity?: Date;
+	closedAt?: Date;
+	duration?: number;
+	messagesSent: number;
+	messagesReceived: number;
+}
+
+/**
+ * Chat message entity.
+ */
+export interface Message {
+	id: string;
+	roomId: string;
+	sessionId: string;
+	nickname: string;
+	text: string;
+	createdAt: Date;
+}
+
+/**
+ * WebSocket client connection.
+ */
+export interface ChatClient {
+	sessionId: string;
+	userId: string;
+	nickname: string;
+}

--- a/packages/examples/chat/src/ws-server.ts
+++ b/packages/examples/chat/src/ws-server.ts
@@ -1,0 +1,258 @@
+/**
+ * @fileoverview WebSocket server for real-time chat
+ *
+ * This server handles WebSocket connections after handoff from the chat-connect command.
+ */
+
+import type { IncomingMessage } from 'http';
+import { type WebSocket, WebSocketServer } from 'ws';
+import { chatService } from './services/chat.js';
+import type { ChatClient } from './types.js';
+
+/**
+ * Room manager for tracking connected clients.
+ */
+class RoomManager {
+	private rooms = new Map<string, Map<WebSocket, ChatClient>>();
+
+	/**
+	 * Join a room.
+	 */
+	join(roomId: string, ws: WebSocket, client: ChatClient): void {
+		if (!this.rooms.has(roomId)) {
+			this.rooms.set(roomId, new Map());
+		}
+		this.rooms.get(roomId)!.set(ws, client);
+	}
+
+	/**
+	 * Leave a room.
+	 */
+	leave(roomId: string, ws: WebSocket): ChatClient | undefined {
+		const room = this.rooms.get(roomId);
+		if (!room) return undefined;
+
+		const client = room.get(ws);
+		room.delete(ws);
+
+		if (room.size === 0) {
+			this.rooms.delete(roomId);
+		}
+
+		return client;
+	}
+
+	/**
+	 * Broadcast a message to all clients in a room.
+	 */
+	broadcast(roomId: string, message: unknown, exclude?: WebSocket): void {
+		const room = this.rooms.get(roomId);
+		if (!room) return;
+
+		const data = JSON.stringify(message);
+		for (const [ws] of room) {
+			if (ws !== exclude && ws.readyState === ws.OPEN) {
+				ws.send(data);
+			}
+		}
+	}
+
+	/**
+	 * Get all clients in a room.
+	 */
+	getClients(roomId: string): ChatClient[] {
+		const room = this.rooms.get(roomId);
+		if (!room) return [];
+		return Array.from(room.values());
+	}
+}
+
+const roomManager = new RoomManager();
+
+/**
+ * Message types from clients.
+ */
+interface ClientMessage {
+	type: 'message' | 'typing' | 'ping';
+	text?: string;
+}
+
+/**
+ * Message types to clients.
+ */
+type ServerMessage =
+	| { type: 'message'; id: string; sender: string; text: string; timestamp: number }
+	| { type: 'user_joined'; nickname: string; timestamp: number }
+	| { type: 'user_left'; nickname: string; timestamp: number }
+	| { type: 'typing'; nickname: string }
+	| { type: 'pong' }
+	| { type: 'error'; message: string }
+	| { type: 'welcome'; roomId: string; participants: string[] };
+
+/**
+ * Create and start the WebSocket server.
+ */
+export function createWebSocketServer(port = 3001): WebSocketServer {
+	const wss = new WebSocketServer({ port });
+
+	wss.on('connection', async (ws: WebSocket, req: IncomingMessage) => {
+		// Parse URL
+		const url = new URL(req.url ?? '/', `ws://${req.headers.host ?? 'localhost'}`);
+		const pathParts = url.pathname.split('/').filter(Boolean);
+
+		// Expect /rooms/:roomId
+		if (pathParts[0] !== 'rooms' || !pathParts[1]) {
+			sendError(ws, 'Invalid path. Use /rooms/:roomId');
+			ws.close(4000, 'Invalid path');
+			return;
+		}
+
+		const roomId = pathParts[1];
+		const token = url.searchParams.get('token');
+
+		if (!token) {
+			sendError(ws, 'Missing token');
+			ws.close(4001, 'Missing token');
+			return;
+		}
+
+		// Validate token
+		const session = chatService.getSessionByToken(token);
+		if (!session) {
+			sendError(ws, 'Invalid token');
+			ws.close(4001, 'Invalid token');
+			return;
+		}
+
+		// Verify session matches room
+		if (session.roomId !== roomId) {
+			sendError(ws, 'Session room mismatch');
+			ws.close(4003, 'Session mismatch');
+			return;
+		}
+
+		// Check session is not expired
+		if (session.expiresAt < new Date()) {
+			sendError(ws, 'Session expired');
+			ws.close(4002, 'Session expired');
+			return;
+		}
+
+		// Mark session as connected
+		chatService.markConnected(session.id);
+
+		// Add to room
+		const client: ChatClient = {
+			sessionId: session.id,
+			userId: session.userId,
+			nickname: session.nickname,
+		};
+		roomManager.join(roomId, ws, client);
+
+		// Send welcome message
+		const participants = roomManager.getClients(roomId).map((c) => c.nickname);
+		send(ws, {
+			type: 'welcome',
+			roomId,
+			participants,
+		});
+
+		// Broadcast join
+		roomManager.broadcast(
+			roomId,
+			{
+				type: 'user_joined',
+				nickname: session.nickname,
+				timestamp: Date.now(),
+			},
+			ws
+		);
+
+		// Handle messages
+		ws.on('message', async (data: Buffer) => {
+			try {
+				const msg = JSON.parse(data.toString()) as ClientMessage;
+
+				switch (msg.type) {
+					case 'message':
+						if (!msg.text) {
+							sendError(ws, 'Message text required');
+							return;
+						}
+
+						const saved = chatService.saveMessage({
+							roomId,
+							sessionId: session.id,
+							nickname: session.nickname,
+							text: msg.text,
+						});
+
+						roomManager.broadcast(roomId, {
+							type: 'message',
+							id: saved.id,
+							sender: session.nickname,
+							text: msg.text,
+							timestamp: saved.createdAt.getTime(),
+						});
+						break;
+
+					case 'typing':
+						roomManager.broadcast(
+							roomId,
+							{
+								type: 'typing',
+								nickname: session.nickname,
+							},
+							ws
+						);
+						break;
+
+					case 'ping':
+						send(ws, { type: 'pong' });
+						chatService.updateActivity(session.id);
+						break;
+
+					default:
+						sendError(ws, 'Unknown message type');
+				}
+			} catch {
+				sendError(ws, 'Invalid message format');
+			}
+		});
+
+		// Handle disconnect
+		ws.on('close', async () => {
+			chatService.markDisconnected(session.id);
+			roomManager.leave(roomId, ws);
+
+			roomManager.broadcast(roomId, {
+				type: 'user_left',
+				nickname: session.nickname,
+				timestamp: Date.now(),
+			});
+		});
+
+		// Handle errors
+		ws.on('error', (error) => {
+			console.error(`WebSocket error for session ${session.id}:`, error);
+		});
+	});
+
+	return wss;
+}
+
+/**
+ * Send a message to a WebSocket client.
+ */
+function send(ws: WebSocket, message: ServerMessage): void {
+	if (ws.readyState === ws.OPEN) {
+		ws.send(JSON.stringify(message));
+	}
+}
+
+/**
+ * Send an error message to a WebSocket client.
+ */
+function sendError(ws: WebSocket, message: string): void {
+	send(ws, { type: 'error', message });
+}

--- a/packages/examples/chat/tsconfig.json
+++ b/packages/examples/chat/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"verbatimModuleSyntax": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/packages/examples/chat/vitest.config.ts
+++ b/packages/examples/chat/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+	},
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "packages/*"
   - "packages/examples/_shared/*"
+  - "packages/examples/chat"
   - "packages/examples/todo/backends/*"
   - "packages/examples/todo/frontends/*"
   - "packages/examples/todo-directclient/backend"


### PR DESCRIPTION
## Summary
- Implements a complete real-time chat example demonstrating the AFD handoff pattern for WebSocket connections as specified in `docs/specs/handoff-pattern/06-example.md`
- Adds 6 new commands: `chat-connect`, `chat-status`, `chat-disconnect`, `chat-poll`, `chat-rooms`, `chat-send`
- Includes WebSocket server for real-time messaging and React component example

## Commands

| Command | Description |
|---------|-------------|
| `chat-connect` | Connect to a chat room, returns WebSocket handoff with credentials |
| `chat-status` | Get status of a chat session |
| `chat-disconnect` | End a chat session |
| `chat-poll` | Polling fallback for agents without WebSocket support |
| `chat-rooms` | List available chat rooms |
| `chat-send` | Send messages to a room (for polling agents) |

## Architecture

```
AFD Server (Commands) -> Chat Service (Sessions) -> WebSocket Server (Real-time)
```

- `ChatService` manages rooms, sessions, and messages in memory
- `chat-connect` creates a session and returns handoff credentials
- WebSocket server validates tokens and handles real-time messaging
- `chat-poll` provides a fallback for agents that cannot use WebSocket

## Test plan
- [x] All 22 unit tests pass
- [x] TypeScript compiles without errors
- [x] Commands follow AFD patterns (CommandResult structure, reasoning, suggestions)
- [x] Handoff metadata includes required fields (protocol, endpoint, credentials, capabilities)

## Files Changed
- `packages/examples/chat/` - New chat example package
- `pnpm-workspace.yaml` - Added chat example to workspace

Closes #22

---
Generated with [Claude Code](https://claude.com/claude-code)