### PR TITLE
feat(client): add browser SDK support

### DIFF
--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -260,7 +260,7 @@ export class HttpTransport implements Transport {
  * Create a transport based on type.
  */
 export function createTransport(
-	type: 'sse' | 'http',
+	type: 'sse' | 'http' | 'websocket',
 	url: string,
 	headers?: Record<string, string>
 ): Transport {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -12,7 +12,7 @@ import type {
 /**
  * Transport type for MCP communication.
  */
-export type TransportType = 'sse' | 'http' | 'stdio' | 'direct';
+export type TransportType = 'sse' | 'http' | 'websocket' | 'stdio' | 'direct';
 
 /**
  * Client configuration options.
@@ -23,7 +23,14 @@ export interface McpClientConfig {
 	 * For SSE: http://localhost:3100/sse
 	 * For HTTP: http://localhost:3100/message
 	 */
-	url: string;
+	url?: string;
+
+	/**
+	 * Server endpoint (alias for url).
+	 * Preferred for browser SDK usage.
+	 * @example 'http://localhost:3100/message'
+	 */
+	endpoint?: string;
 
 	/**
 	 * Transport type to use.


### PR DESCRIPTION
## Summary
Adds browser SDK support to the @lushly-dev/afd-client package with the following features:

- Add `websocket` to TransportType union for WebSocket transport support
- Add optional `endpoint` field as alias for `url` in config (browser-friendly API)
- Add `ResolvedConfig` type to handle url/endpoint resolution
- Update constructor to validate and resolve url from either `url` or `endpoint`
- Update `createTransport` signature to support websocket type

## Changes

### types.ts
- Added `websocket` to `TransportType` union
- Made `url` optional
- Added `endpoint` as optional alias for `url` with documentation

### client.ts
- Added `ResolvedConfig` type for proper type handling when url is resolved
- Updated constructor to resolve url from `url` or `endpoint`
- Added validation to ensure at least one is provided

### transport.ts
- Updated `createTransport` signature to accept `websocket` type

## API Usage

```typescript
// Traditional usage
const client = createClient({ url: 'http://localhost:3100/sse' });

// Browser SDK usage (preferred)
const client = createClient({ endpoint: 'http://localhost:3100/message' });
await client.connect();
const result = await client.call('todo.create', { title: 'Test' });
```

## Test plan
- [x] Build passes (`pnpm --filter @lushly-dev/afd-client build`)
- [x] All 81 tests pass (`pnpm --filter @lushly-dev/afd-client test`)
- [x] TypeScript strict mode compliant
- [ ] Integration test with browser client (manual testing needed)

## Follow-up work
- WebSocket transport class implementation
- `execute()` method as alias for `call()`

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)