### PR TITLE
feat(todo-ts): add list commands for grouping todos

### DIFF
--- a/packages/examples/todo/backends/typescript/src/commands/__tests__/list-commands.test.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/__tests__/list-commands.test.ts
@@ -1,0 +1,354 @@
+/**
+ * @fileoverview Unit tests for list commands
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { store } from '../../store/memory.js';
+import { createList } from '../list-create.js';
+import { updateList } from '../list-update.js';
+import { deleteList } from '../list-delete.js';
+import { listLists } from '../list-list.js';
+import { createTodo } from '../create.js';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST SETUP
+// ═══════════════════════════════════════════════════════════════════════════════
+
+beforeEach(() => {
+	store.clear();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// list-create
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('list-create', () => {
+	it('creates a list with required fields', async () => {
+		const result = await createList.handler({ name: 'My List' }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.name).toBe('My List');
+		expect(result.data?.todoIds).toEqual([]);
+		expect(result.data?.id).toBeDefined();
+		expect(result.data?.createdAt).toBeDefined();
+	});
+
+	it('creates a list with description', async () => {
+		const result = await createList.handler({
+			name: 'Work Tasks',
+			description: 'Tasks for work projects',
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.name).toBe('Work Tasks');
+		expect(result.data?.description).toBe('Tasks for work projects');
+	});
+
+	it('creates a list with todoIds', async () => {
+		// Create some todos first
+		const todo1 = await createTodo.handler({ title: 'Todo 1', priority: 'medium' }, {});
+		const todo2 = await createTodo.handler({ title: 'Todo 2', priority: 'high' }, {});
+
+		const result = await createList.handler({
+			name: 'Project List',
+			todoIds: [todo1.data!.id, todo2.data!.id],
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.todoIds).toHaveLength(2);
+		expect(result.data?.todoIds).toContain(todo1.data!.id);
+		expect(result.data?.todoIds).toContain(todo2.data!.id);
+	});
+
+	it('returns confidence of 1.0', async () => {
+		const result = await createList.handler({ name: 'Test List' }, {});
+
+		expect(result.confidence).toBe(1.0);
+	});
+
+	it('includes reasoning', async () => {
+		const result = await createList.handler({ name: 'My List' }, {});
+
+		expect(result.reasoning).toContain('My List');
+	});
+
+	it('includes todo count in reasoning when todoIds provided', async () => {
+		const todo = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const result = await createList.handler({
+			name: 'With Todos',
+			todoIds: [todo.data!.id],
+		}, {});
+
+		expect(result.reasoning).toContain('1 todo');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// list-list
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('list-list', () => {
+	beforeEach(async () => {
+		await createList.handler({ name: 'List 1', description: 'First list' }, {});
+		await createList.handler({ name: 'List 2', description: 'Second list' }, {});
+		await createList.handler({ name: 'Work Items' }, {});
+	});
+
+	it('lists all lists', async () => {
+		const result = await listLists.handler({
+			sortBy: 'createdAt',
+			sortOrder: 'desc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.lists).toHaveLength(3);
+		expect(result.data?.total).toBe(3);
+		expect(result.data?.hasMore).toBe(false);
+	});
+
+	it('searches by name', async () => {
+		const result = await listLists.handler({
+			search: 'Work',
+			sortBy: 'createdAt',
+			sortOrder: 'desc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.lists).toHaveLength(1);
+		expect(result.data?.lists[0].name).toBe('Work Items');
+	});
+
+	it('searches by description', async () => {
+		const result = await listLists.handler({
+			search: 'First',
+			sortBy: 'createdAt',
+			sortOrder: 'desc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.lists).toHaveLength(1);
+		expect(result.data?.lists[0].name).toBe('List 1');
+	});
+
+	it('supports pagination', async () => {
+		const page1 = await listLists.handler({
+			limit: 2,
+			offset: 0,
+			sortBy: 'createdAt',
+			sortOrder: 'desc',
+		}, {});
+		const page2 = await listLists.handler({
+			limit: 2,
+			offset: 2,
+			sortBy: 'createdAt',
+			sortOrder: 'desc',
+		}, {});
+
+		expect(page1.data?.lists).toHaveLength(2);
+		expect(page1.data?.hasMore).toBe(true);
+		expect(page2.data?.lists).toHaveLength(1);
+		expect(page2.data?.hasMore).toBe(false);
+	});
+
+	it('sorts by name', async () => {
+		const result = await listLists.handler({
+			sortBy: 'name',
+			sortOrder: 'asc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.data?.lists[0].name).toBe('List 1');
+		expect(result.data?.lists[1].name).toBe('List 2');
+		expect(result.data?.lists[2].name).toBe('Work Items');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// list-update
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('list-update', () => {
+	it('updates list name', async () => {
+		const created = await createList.handler({ name: 'Original' }, {});
+
+		const result = await updateList.handler({
+			id: created.data!.id,
+			name: 'Updated Name',
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.name).toBe('Updated Name');
+		expect(result.data?.updatedAt).toBeDefined();
+	});
+
+	it('updates list description', async () => {
+		const created = await createList.handler({ name: 'Test List' }, {});
+
+		const result = await updateList.handler({
+			id: created.data!.id,
+			description: 'New description',
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.description).toBe('New description');
+	});
+
+	it('updates list todoIds', async () => {
+		const todo = await createTodo.handler({ title: 'New Todo', priority: 'medium' }, {});
+		const created = await createList.handler({ name: 'Test List' }, {});
+
+		const result = await updateList.handler({
+			id: created.data!.id,
+			todoIds: [todo.data!.id],
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.todoIds).toContain(todo.data!.id);
+	});
+
+	it('returns NOT_FOUND for missing list', async () => {
+		const result = await updateList.handler({
+			id: 'nonexistent',
+			name: 'New name',
+		}, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('NOT_FOUND');
+	});
+
+	it('returns NO_CHANGES when nothing to update', async () => {
+		const created = await createList.handler({ name: 'Test' }, {});
+		const result = await updateList.handler({ id: created.data!.id }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('NO_CHANGES');
+	});
+
+	it('includes reasoning with change summary', async () => {
+		const created = await createList.handler({ name: 'Original' }, {});
+		const result = await updateList.handler({
+			id: created.data!.id,
+			name: 'New Name',
+		}, {});
+
+		expect(result.reasoning).toContain('name');
+		expect(result.reasoning).toContain('New Name');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// list-delete
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('list-delete', () => {
+	it('deletes a list', async () => {
+		const created = await createList.handler({ name: 'Delete me' }, {});
+		const result = await deleteList.handler({ id: created.data!.id }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.deleted).toBe(true);
+
+		// Verify it's gone
+		const lists = await listLists.handler({
+			sortBy: 'createdAt',
+			sortOrder: 'desc',
+			limit: 20,
+			offset: 0,
+		}, {});
+		expect(lists.data?.lists).toHaveLength(0);
+	});
+
+	it('includes warning about permanence', async () => {
+		const created = await createList.handler({ name: 'Delete me' }, {});
+		const result = await deleteList.handler({ id: created.data!.id }, {});
+
+		expect(result.warnings).toBeDefined();
+		expect(result.warnings?.[0].code).toBe('PERMANENT');
+	});
+
+	it('returns NOT_FOUND for missing list', async () => {
+		const result = await deleteList.handler({ id: 'nonexistent' }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('NOT_FOUND');
+	});
+
+	it('includes list name in reasoning', async () => {
+		const created = await createList.handler({ name: 'My Special List' }, {});
+		const result = await deleteList.handler({ id: created.data!.id }, {});
+
+		expect(result.reasoning).toContain('My Special List');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// AFD Compliance Tests for List Commands
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('List Commands AFD Compliance', () => {
+	it('all list commands return valid CommandResult structure', async () => {
+		const created = await createList.handler({ name: 'Test' }, {});
+
+		const commands = [
+			() => createList.handler({ name: 'New List' }, {}),
+			() => listLists.handler({ sortBy: 'createdAt', sortOrder: 'desc', limit: 20, offset: 0 }, {}),
+			() => updateList.handler({ id: created.data!.id, name: 'Updated' }, {}),
+		];
+
+		for (const cmd of commands) {
+			const result = await cmd();
+
+			expect(result).toHaveProperty('success');
+			expect(typeof result.success).toBe('boolean');
+
+			if (result.success) {
+				expect(result).toHaveProperty('data');
+			} else {
+				expect(result).toHaveProperty('error');
+				expect(result.error).toHaveProperty('code');
+				expect(result.error).toHaveProperty('message');
+			}
+		}
+	});
+
+	it('success results include confidence', async () => {
+		const result = await createList.handler({ name: 'Test' }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.confidence).toBeGreaterThanOrEqual(0);
+		expect(result.confidence).toBeLessThanOrEqual(1);
+	});
+
+	it('success results include reasoning', async () => {
+		const result = await createList.handler({ name: 'Test' }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.reasoning).toBeDefined();
+		expect(typeof result.reasoning).toBe('string');
+		expect(result.reasoning!.length).toBeGreaterThan(0);
+	});
+
+	it('error results include suggestion', async () => {
+		const result = await updateList.handler({ id: 'nonexistent', name: 'Test' }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.suggestion).toBeDefined();
+	});
+
+	it('mutation commands include warnings when appropriate', async () => {
+		const created = await createList.handler({ name: 'Test' }, {});
+		const result = await deleteList.handler({ id: created.data!.id }, {});
+
+		expect(result.warnings).toBeDefined();
+		expect(result.warnings!.length).toBeGreaterThan(0);
+		expect(result.warnings![0]).toHaveProperty('code');
+		expect(result.warnings![0]).toHaveProperty('message');
+	});
+});

--- a/packages/examples/todo/backends/typescript/src/commands/index.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/index.ts
@@ -16,6 +16,12 @@ export { createBatch, type BatchCreateResult, type FailedItem } from './create-b
 export { deleteBatch, type BatchDeleteResult, type FailedDelete } from './delete-batch.js';
 export { toggleBatch, type BatchToggleResult, type FailedToggle } from './toggle-batch.js';
 
+// List operations
+export { createList } from './list-create.js';
+export { updateList } from './list-update.js';
+export { deleteList, type ListDeleteResult } from './list-delete.js';
+export { listLists, type ListListResult } from './list-list.js';
+
 // Re-export as array for convenience
 import { createTodo } from './create.js';
 import { listTodos } from './list.js';
@@ -28,6 +34,11 @@ import { getStats } from './stats.js';
 import { createBatch } from './create-batch.js';
 import { deleteBatch } from './delete-batch.js';
 import { toggleBatch } from './toggle-batch.js';
+// List operations
+import { createList } from './list-create.js';
+import { updateList } from './list-update.js';
+import { deleteList } from './list-delete.js';
+import { listLists } from './list-list.js';
 import type { ZodCommandDefinition } from '@afd/server';
 
 /**
@@ -48,4 +59,9 @@ export const allCommands = [
 	createBatch,
 	deleteBatch,
 	toggleBatch,
+	// List operations
+	createList,
+	updateList,
+	deleteList,
+	listLists,
 ] as unknown as ZodCommandDefinition[];

--- a/packages/examples/todo/backends/typescript/src/commands/list-create.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-create.ts
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview list-create command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success } from '@afd/server';
+import { store } from '../store/index.js';
+import type { List } from '../types.js';
+
+const inputSchema = z.object({
+	name: z.string().min(1, 'Name is required').max(100, 'Name too long'),
+	description: z.string().max(500).optional(),
+	todoIds: z.array(z.string()).optional(),
+});
+
+export const createList = defineCommand<typeof inputSchema, List>({
+	name: 'list-create',
+	description: 'Create a new list to group todos',
+	category: 'list',
+	tags: ['list', 'create', 'write', 'single'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['VALIDATION_ERROR'],
+
+	async handler(input) {
+		const list = store.createList({
+			name: input.name,
+			description: input.description,
+			todoIds: input.todoIds,
+		});
+
+		const todoCount = input.todoIds?.length ?? 0;
+		const todoText = todoCount > 0 ? ` with ${todoCount} todo${todoCount === 1 ? '' : 's'}` : '';
+
+		return success(list, {
+			reasoning: `Created list "${list.name}"${todoText}`,
+			confidence: 1.0,
+		});
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/list-delete.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-delete.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview list-delete command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success, failure } from '@afd/server';
+import { store } from '../store/index.js';
+
+const inputSchema = z.object({
+	id: z.string().min(1, 'List ID is required'),
+});
+
+export interface ListDeleteResult {
+	deleted: boolean;
+	id: string;
+}
+
+export const deleteList = defineCommand<typeof inputSchema, ListDeleteResult>({
+	name: 'list-delete',
+	description: 'Delete a list',
+	category: 'list',
+	tags: ['list', 'delete', 'write', 'single', 'destructive'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['NOT_FOUND'],
+
+	async handler(input) {
+		const existing = store.getList(input.id);
+		if (!existing) {
+			return failure({
+				code: 'NOT_FOUND',
+				message: `List with ID "${input.id}" not found`,
+				suggestion: 'Use list-list to see available lists',
+			});
+		}
+
+		const deleted = store.deleteList(input.id);
+
+		if (!deleted) {
+			return failure({
+				code: 'NOT_FOUND',
+				message: `List with ID "${input.id}" not found`,
+				suggestion: 'Use list-list to see available lists',
+			});
+		}
+
+		return success(
+			{ deleted: true, id: input.id },
+			{
+				reasoning: `Deleted list "${existing.name}"`,
+				confidence: 1.0,
+				warnings: [
+					{
+						code: 'PERMANENT',
+						message: 'This action cannot be undone',
+						severity: 'info',
+					},
+				],
+			}
+		);
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/list-list.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-list.ts
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview list-list command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success } from '@afd/server';
+import { store } from '../store/index.js';
+import type { List } from '../types.js';
+
+const inputSchema = z.object({
+	search: z.string().optional(),
+	sortBy: z.enum(['createdAt', 'updatedAt', 'name']).default('createdAt'),
+	sortOrder: z.enum(['asc', 'desc']).default('desc'),
+	limit: z.number().int().min(1).max(100).default(20),
+	offset: z.number().int().min(0).default(0),
+});
+
+export interface ListListResult {
+	lists: List[];
+	total: number;
+	hasMore: boolean;
+}
+
+export const listLists = defineCommand<typeof inputSchema, ListListResult>({
+	name: 'list-list',
+	description: 'List all lists with optional filtering and pagination',
+	category: 'list',
+	tags: ['list', 'list', 'read'],
+	mutation: false,
+	version: '1.0.0',
+	input: inputSchema,
+
+	async handler(input) {
+		const lists = store.listLists({
+			search: input.search,
+			sortBy: input.sortBy,
+			sortOrder: input.sortOrder,
+			limit: input.limit,
+			offset: input.offset,
+		});
+
+		// Get total count for pagination
+		const allMatching = store.listLists({
+			search: input.search,
+		});
+
+		const total = allMatching.length;
+		const hasMore = input.offset + lists.length < total;
+
+		// Build reasoning
+		const filters: string[] = [];
+		if (input.search) {
+			filters.push(`matching "${input.search}"`);
+		}
+
+		const filterText = filters.length > 0 ? ` (${filters.join(', ')})` : '';
+
+		return success(
+			{ lists, total, hasMore },
+			{
+				reasoning: `Found ${total} lists${filterText}, returning ${lists.length} starting at offset ${input.offset}`,
+				confidence: 1.0,
+			}
+		);
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/list-update.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-update.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview list-update command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success, failure } from '@afd/server';
+import { store } from '../store/index.js';
+import type { List } from '../types.js';
+
+const inputSchema = z.object({
+	id: z.string().min(1, 'List ID is required'),
+	name: z.string().min(1).max(100).optional(),
+	description: z.string().max(500).optional(),
+	todoIds: z.array(z.string()).optional(),
+});
+
+export const updateList = defineCommand<typeof inputSchema, List>({
+	name: 'list-update',
+	description: 'Update a list',
+	category: 'list',
+	tags: ['list', 'update', 'write', 'single'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['NOT_FOUND', 'NO_CHANGES'],
+
+	async handler(input) {
+		const { id, ...updates } = input;
+
+		// Check if there are any changes
+		const hasChanges = Object.values(updates).some((v) => v !== undefined);
+		if (!hasChanges) {
+			return failure({
+				code: 'NO_CHANGES',
+				message: 'No fields to update',
+				suggestion: 'Provide at least one of: name, description, todoIds',
+			});
+		}
+
+		const existing = store.getList(id);
+		if (!existing) {
+			return failure({
+				code: 'NOT_FOUND',
+				message: `List with ID "${id}" not found`,
+				suggestion: 'Use list-list to see available lists',
+			});
+		}
+
+		const updated = store.updateList(id, {
+			name: updates.name,
+			description: updates.description,
+			todoIds: updates.todoIds,
+		});
+
+		if (!updated) {
+			return failure({
+				code: 'NOT_FOUND',
+				message: `List with ID "${id}" not found`,
+				suggestion: 'Use list-list to see available lists',
+			});
+		}
+
+		// Build change summary
+		const changes: string[] = [];
+		if (updates.name) changes.push(`name to "${updates.name}"`);
+		if (updates.description !== undefined) changes.push('description');
+		if (updates.todoIds !== undefined) changes.push(`todoIds (${updates.todoIds.length} items)`);
+
+		return success(updated, {
+			reasoning: `Updated ${changes.join(', ')} for list "${updated.name}"`,
+			confidence: 1.0,
+		});
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/types.ts
+++ b/packages/examples/todo/backends/typescript/src/types.ts
@@ -85,3 +85,46 @@ export interface TodoFilter {
 	/** Offset for pagination */
 	offset?: number;
 }
+
+/**
+ * A list that groups todos together.
+ */
+export interface List {
+	/** Unique identifier */
+	id: string;
+
+	/** List name */
+	name: string;
+
+	/** Optional description */
+	description?: string;
+
+	/** IDs of todos in this list */
+	todoIds: string[];
+
+	/** Creation timestamp */
+	createdAt: string;
+
+	/** Last update timestamp */
+	updatedAt: string;
+}
+
+/**
+ * Filter options for listing lists.
+ */
+export interface ListFilter {
+	/** Search in name/description */
+	search?: string;
+
+	/** Sort field */
+	sortBy?: 'createdAt' | 'updatedAt' | 'name';
+
+	/** Sort direction */
+	sortOrder?: 'asc' | 'desc';
+
+	/** Maximum results */
+	limit?: number;
+
+	/** Offset for pagination */
+	offset?: number;
+}


### PR DESCRIPTION
## Summary

- Implements list commands (`list-create`, `list-update`, `list-delete`, `list-list`) for the Todo Demo TypeScript backend
- Adds `List` and `ListFilter` types to support grouping todos into named lists
- Includes store implementations for both memory and file-based persistence
- Comprehensive test coverage including AFD compliance validation

## Changes

### New Commands
| Command | Description |
|---------|-------------|
| `list-create` | Create a new list with name, description, and optional todoIds |
| `list-update` | Update list name, description, or todoIds |
| `list-delete` | Delete a list (with PERMANENT warning) |
| `list-list` | List all lists with search, sorting, and pagination |

### Files Changed
- `types.ts` - Added `List` and `ListFilter` interfaces
- `store/memory.ts` - Added list CRUD methods to in-memory store
- `store/file.ts` - Added list CRUD methods to file-based store
- `commands/list-*.ts` - New list command implementations
- `commands/index.ts` - Registered list commands
- `commands/__tests__/list-commands.test.ts` - Comprehensive tests

## Test Plan

- [x] Unit tests for all list commands
- [x] Error case coverage (NOT_FOUND, NO_CHANGES)
- [x] AFD compliance tests (CommandResult structure, confidence, reasoning, warnings)
- [ ] Manual testing via `afd call` (blocked by pre-existing `@afd/server` module resolution issue)

**Note:** Build and tests fail due to a pre-existing infrastructure issue where the example imports from `@afd/server` but the workspace package is `@lushly-dev/afd-server`. This issue predates this PR.

Closes #65

🤖 Generated with [Claude Code](https://claude.ai/code)