### PR TITLE
feat(todo-ts): add todo-complete and todo-uncomplete commands

### DIFF
--- a/packages/examples/todo/backends/typescript/src/commands/__tests__/complete.test.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/__tests__/complete.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview Unit tests for todo-complete and todo-uncomplete commands
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { store } from '../../store/memory.js';
+import { createTodo } from '../create.js';
+import { completeTodo } from '../complete.js';
+import { uncompleteTodo } from '../uncomplete.js';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST SETUP
+// ═══════════════════════════════════════════════════════════════════════════════
+
+beforeEach(() => {
+	store.clear();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// todo-complete
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('todo-complete', () => {
+	it('marks todo as completed', async () => {
+		const created = await createTodo.handler({ title: 'Complete me', priority: 'medium' }, {});
+		const result = await completeTodo.handler({ id: created.data!.id }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.completed).toBe(true);
+		expect(result.data?.completedAt).toBeDefined();
+		expect(result.reasoning).toContain('completed');
+	});
+
+	it('returns ALREADY_COMPLETED for completed todo', async () => {
+		const created = await createTodo.handler({ title: 'Already done', priority: 'medium' }, {});
+		await completeTodo.handler({ id: created.data!.id }, {});
+		const result = await completeTodo.handler({ id: created.data!.id }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('ALREADY_COMPLETED');
+		expect(result.error?.suggestion).toBeDefined();
+	});
+
+	it('returns NOT_FOUND for missing todo', async () => {
+		const result = await completeTodo.handler({ id: 'nonexistent' }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('NOT_FOUND');
+		expect(result.error?.suggestion).toBeDefined();
+	});
+
+	it('returns confidence of 1.0', async () => {
+		const created = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const result = await completeTodo.handler({ id: created.data!.id }, {});
+
+		expect(result.confidence).toBe(1.0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// todo-uncomplete
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('todo-uncomplete', () => {
+	it('marks todo as pending', async () => {
+		const created = await createTodo.handler({ title: 'Uncomplete me', priority: 'medium' }, {});
+		await completeTodo.handler({ id: created.data!.id }, {});
+		const result = await uncompleteTodo.handler({ id: created.data!.id }, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.completed).toBe(false);
+		expect(result.data?.completedAt).toBeUndefined();
+		expect(result.reasoning).toContain('pending');
+	});
+
+	it('returns NOT_COMPLETED for pending todo', async () => {
+		const created = await createTodo.handler({ title: 'Still pending', priority: 'medium' }, {});
+		const result = await uncompleteTodo.handler({ id: created.data!.id }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('NOT_COMPLETED');
+		expect(result.error?.suggestion).toBeDefined();
+	});
+
+	it('returns NOT_FOUND for missing todo', async () => {
+		const result = await uncompleteTodo.handler({ id: 'nonexistent' }, {});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('NOT_FOUND');
+		expect(result.error?.suggestion).toBeDefined();
+	});
+
+	it('returns confidence of 1.0', async () => {
+		const created = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		await completeTodo.handler({ id: created.data!.id }, {});
+		const result = await uncompleteTodo.handler({ id: created.data!.id }, {});
+
+		expect(result.confidence).toBe(1.0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// complete/uncomplete interaction
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('complete/uncomplete interaction', () => {
+	it('can complete and uncomplete repeatedly', async () => {
+		const created = await createTodo.handler({ title: 'Toggle test', priority: 'medium' }, {});
+
+		// Complete
+		let result = await completeTodo.handler({ id: created.data!.id }, {});
+		expect(result.data?.completed).toBe(true);
+
+		// Uncomplete
+		result = await uncompleteTodo.handler({ id: created.data!.id }, {});
+		expect(result.data?.completed).toBe(false);
+
+		// Complete again
+		result = await completeTodo.handler({ id: created.data!.id }, {});
+		expect(result.data?.completed).toBe(true);
+		expect(result.data?.completedAt).toBeDefined();
+	});
+
+	it('updates timestamps correctly', async () => {
+		const created = await createTodo.handler({ title: 'Timestamp test', priority: 'medium' }, {});
+		const originalUpdatedAt = created.data!.updatedAt;
+
+		// Small delay to ensure timestamps differ
+		await new Promise(resolve => setTimeout(resolve, 5));
+
+		const completed = await completeTodo.handler({ id: created.data!.id }, {});
+		expect(completed.data?.updatedAt).toBeDefined();
+		expect(completed.data?.completedAt).toBeDefined();
+
+		// Small delay again
+		await new Promise(resolve => setTimeout(resolve, 5));
+
+		const uncompleted = await uncompleteTodo.handler({ id: created.data!.id }, {});
+		expect(uncompleted.data?.completedAt).toBeUndefined();
+		expect(uncompleted.data?.updatedAt).toBeDefined();
+	});
+});

--- a/packages/examples/todo/backends/typescript/src/commands/complete.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/complete.ts
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview todo-complete command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success, failure } from '@afd/server';
+import { store } from '../store/index.js';
+import type { Todo } from '../types.js';
+
+const inputSchema = z.object({
+	id: z.string().min(1, 'Todo ID is required'),
+});
+
+export const completeTodo = defineCommand<typeof inputSchema, Todo>({
+	name: 'todo-complete',
+	description: 'Mark a todo as completed',
+	category: 'todo',
+	tags: ['todo', 'complete', 'write', 'single'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['NOT_FOUND', 'ALREADY_COMPLETED'],
+
+	async handler(input) {
+		const existing = store.get(input.id);
+		if (!existing) {
+			return failure({
+				code: 'NOT_FOUND',
+				message: `Todo with ID "${input.id}" not found`,
+				suggestion: 'Use todo-list to see available todos',
+			});
+		}
+
+		if (existing.completed) {
+			return failure({
+				code: 'ALREADY_COMPLETED',
+				message: `Todo "${existing.title}" is already completed`,
+				suggestion: 'Use todo-uncomplete to mark it as pending, or todo-toggle to switch the status',
+			});
+		}
+
+		const updated = store.update(input.id, { completed: true });
+
+		if (!updated) {
+			return failure({
+				code: 'NOT_FOUND',
+				message: `Todo with ID "${input.id}" not found`,
+				suggestion: 'Use todo-list to see available todos',
+			});
+		}
+
+		return success(updated, {
+			reasoning: `Marked as completed: "${updated.title}"`,
+			confidence: 1.0,
+		});
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/index.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/index.ts
@@ -7,6 +7,8 @@ export { listTodos, type ListResult } from './list.js';
 export { getTodo } from './get.js';
 export { updateTodo } from './update.js';
 export { toggleTodo } from './toggle.js';
+export { completeTodo } from './complete.js';
+export { uncompleteTodo } from './uncomplete.js';
 export { deleteTodo, type DeleteResult } from './delete.js';
 export { clearCompleted, type ClearResult } from './clear.js';
 export { getStats } from './stats.js';
@@ -28,6 +30,8 @@ import { listTodos } from './list.js';
 import { getTodo } from './get.js';
 import { updateTodo } from './update.js';
 import { toggleTodo } from './toggle.js';
+import { completeTodo } from './complete.js';
+import { uncompleteTodo } from './uncomplete.js';
 import { deleteTodo } from './delete.js';
 import { clearCompleted } from './clear.js';
 import { getStats } from './stats.js';
@@ -52,6 +56,8 @@ export const allCommands = [
 	getTodo,
 	updateTodo,
 	toggleTodo,
+	completeTodo,
+	uncompleteTodo,
 	deleteTodo,
 	clearCompleted,
 	getStats,

--- a/packages/examples/todo/backends/typescript/src/commands/uncomplete.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/uncomplete.ts
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview todo-uncomplete command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success, failure } from '@afd/server';
+import { store } from '../store/index.js';
+import type { Todo } from '../types.js';
+
+const inputSchema = z.object({
+	id: z.string().min(1, 'Todo ID is required'),
+});
+
+export const uncompleteTodo = defineCommand<typeof inputSchema, Todo>({
+	name: 'todo-uncomplete',
+	description: 'Mark a todo as not completed (pending)',
+	category: 'todo',
+	tags: ['todo', 'uncomplete', 'write', 'single'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['NOT_FOUND', 'NOT_COMPLETED'],
+
+	async handler(input) {
+		const existing = store.get(input.id);
+		if (!existing) {
+			return failure({
+				code: 'NOT_FOUND',
+				message: `Todo with ID "${input.id}" not found`,
+				suggestion: 'Use todo-list to see available todos',
+			});
+		}
+
+		if (!existing.completed) {
+			return failure({
+				code: 'NOT_COMPLETED',
+				message: `Todo "${existing.title}" is not completed`,
+				suggestion: 'Use todo-complete to mark it as completed, or todo-toggle to switch the status',
+			});
+		}
+
+		const updated = store.update(input.id, { completed: false });
+
+		if (!updated) {
+			return failure({
+				code: 'NOT_FOUND',
+				message: `Todo with ID "${input.id}" not found`,
+				suggestion: 'Use todo-list to see available todos',
+			});
+		}
+
+		return success(updated, {
+			reasoning: `Marked as pending: "${updated.title}"`,
+			confidence: 1.0,
+		});
+	},
+});


### PR DESCRIPTION
## Summary

- Add `todo-complete` command to explicitly mark a todo as completed
- Add `todo-uncomplete` command to mark a todo as pending (not completed)
- Both commands return actionable error messages with appropriate error codes

## Implementation Details

**Commands Added:**
- `todo-complete`: Mark a todo as completed (returns `ALREADY_COMPLETED` error if already done)
- `todo-uncomplete`: Mark a todo as pending (returns `NOT_COMPLETED` error if already pending)

**AFD Compliance:**
- Uses `domain-action` naming convention
- Returns proper CommandResult with reasoning and confidence
- Error results include actionable suggestions for recovery
- Input validated with Zod schema
- Mutation commands properly flagged

## Test plan

- [x] Unit tests pass (10 tests covering success/failure cases)
- [x] `todo-complete` marks pending todo as completed
- [x] `todo-complete` returns ALREADY_COMPLETED for completed todo
- [x] `todo-uncomplete` marks completed todo as pending
- [x] `todo-uncomplete` returns NOT_COMPLETED for pending todo
- [x] Both commands return NOT_FOUND for invalid IDs
- [x] State transitions work correctly (complete -> uncomplete -> complete)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)