### PR TITLE
feat(todo-ts): add today/upcoming views with due date filtering

### DIFF
--- a/packages/examples/todo/backends/typescript/src/commands/__tests__/due-date.test.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/__tests__/due-date.test.ts
@@ -1,0 +1,430 @@
+/**
+ * @fileoverview Unit tests for due date filtering commands
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { store } from '../../store/index.js';
+import { createTodo } from '../create.js';
+import { updateTodo } from '../update.js';
+import { listTodos } from '../list.js';
+import { listToday } from '../list-today.js';
+import { listUpcoming } from '../list-upcoming.js';
+import { getStats } from '../stats.js';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST SETUP
+// ═══════════════════════════════════════════════════════════════════════════════
+
+beforeEach(() => {
+	store.clear();
+});
+
+// Helper to create date at specific offset from today
+function getDateOffset(days: number): string {
+	const date = new Date();
+	date.setDate(date.getDate() + days);
+	return date.toISOString();
+}
+
+// Helper to get start of today
+function getStartOfToday(): Date {
+	const now = new Date();
+	return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+}
+
+// Helper to get end of today
+function getEndOfToday(): Date {
+	const now = new Date();
+	return new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// todo-create with dueDate
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('todo-create with dueDate', () => {
+	it('creates a todo with a due date', async () => {
+		const dueDate = getDateOffset(1);
+		const result = await createTodo.handler(
+			{ title: 'Due tomorrow', priority: 'high', dueDate },
+			{}
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.data?.dueDate).toBe(dueDate);
+		expect(result.reasoning).toContain('due');
+	});
+
+	it('creates a todo without a due date', async () => {
+		const result = await createTodo.handler(
+			{ title: 'No due date', priority: 'medium' },
+			{}
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.data?.dueDate).toBeUndefined();
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// todo-update with dueDate
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('todo-update with dueDate', () => {
+	it('updates a todo with a due date', async () => {
+		const created = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const dueDate = getDateOffset(3);
+
+		const result = await updateTodo.handler(
+			{ id: created.data!.id, dueDate },
+			{}
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.data?.dueDate).toBe(dueDate);
+		expect(result.reasoning).toContain('due date');
+	});
+
+	it('clears a due date by setting to null', async () => {
+		const dueDate = getDateOffset(1);
+		const created = await createTodo.handler(
+			{ title: 'Has due date', priority: 'medium', dueDate },
+			{}
+		);
+
+		const result = await updateTodo.handler(
+			{ id: created.data!.id, dueDate: null },
+			{}
+		);
+
+		expect(result.success).toBe(true);
+		// dueDate should be cleared (either undefined or null)
+		expect(result.data?.dueDate == null).toBe(true);
+		expect(result.reasoning).toContain('cleared due date');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// todo-list with due date filters
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('todo-list with due date filters', () => {
+	beforeEach(async () => {
+		// Create todos with various due dates
+		await createTodo.handler({ title: 'Overdue', priority: 'high', dueDate: getDateOffset(-2) }, {});
+		await createTodo.handler({ title: 'Due today', priority: 'medium', dueDate: new Date().toISOString() }, {});
+		await createTodo.handler({ title: 'Due tomorrow', priority: 'low', dueDate: getDateOffset(1) }, {});
+		await createTodo.handler({ title: 'Due next week', priority: 'medium', dueDate: getDateOffset(7) }, {});
+		await createTodo.handler({ title: 'No due date', priority: 'low' }, {});
+	});
+
+	it('filters by dueBefore', async () => {
+		// Use start of today to get only items with due date strictly before today
+		const startOfToday = new Date();
+		startOfToday.setHours(0, 0, 0, 0);
+
+		const result = await listTodos.handler({
+			dueBefore: startOfToday.toISOString(),
+			sortBy: 'dueDate',
+			sortOrder: 'asc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		// Should include only overdue item (due before start of today)
+		expect(result.data?.todos.length).toBe(1);
+		expect(result.data?.todos[0].title).toBe('Overdue');
+	});
+
+	it('filters by dueAfter', async () => {
+		const result = await listTodos.handler({
+			dueAfter: getDateOffset(0),
+			sortBy: 'dueDate',
+			sortOrder: 'asc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		// Should include due today, tomorrow, and next week
+		expect(result.data?.todos.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it('filters by overdue status', async () => {
+		const result = await listTodos.handler({
+			overdue: true,
+			sortBy: 'dueDate',
+			sortOrder: 'asc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.todos.length).toBe(1);
+		expect(result.data?.todos[0].title).toBe('Overdue');
+	});
+
+	it('sorts by dueDate', async () => {
+		const result = await listTodos.handler({
+			sortBy: 'dueDate',
+			sortOrder: 'asc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		// First items should have earliest due dates
+		const todosWithDueDates = result.data?.todos.filter((t) => t.dueDate);
+		expect(todosWithDueDates?.length).toBeGreaterThan(0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// todo-list-today
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('todo-list-today', () => {
+	it('returns empty result when no todos due today', async () => {
+		const result = await listToday.handler({
+			includeOverdue: false,
+			includeCompleted: false,
+			sortBy: 'priority',
+			sortOrder: 'desc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.todos).toHaveLength(0);
+		expect(result.data?.todayCount).toBe(0);
+		expect(result.reasoning).toContain('No tasks due today');
+	});
+
+	it('returns todos due today', async () => {
+		// Create a todo due today
+		const today = new Date();
+		today.setHours(12, 0, 0, 0);
+		await createTodo.handler({ title: 'Due today', priority: 'high', dueDate: today.toISOString() }, {});
+
+		const result = await listToday.handler({
+			includeOverdue: false,
+			includeCompleted: false,
+			sortBy: 'priority',
+			sortOrder: 'desc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.todayCount).toBe(1);
+		expect(result.data?.todos[0].title).toBe('Due today');
+	});
+
+	it('includes overdue todos when flag is set', async () => {
+		// Create overdue todo
+		await createTodo.handler({ title: 'Overdue task', priority: 'high', dueDate: getDateOffset(-2) }, {});
+
+		const withOverdue = await listToday.handler({
+			includeOverdue: true,
+			includeCompleted: false,
+			sortBy: 'priority',
+			sortOrder: 'desc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		const withoutOverdue = await listToday.handler({
+			includeOverdue: false,
+			includeCompleted: false,
+			sortBy: 'priority',
+			sortOrder: 'desc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(withOverdue.data?.overdueCount).toBe(1);
+		expect(withoutOverdue.data?.overdueCount).toBe(0);
+	});
+
+	it('provides alternatives when no tasks today', async () => {
+		// Create a future todo
+		await createTodo.handler({ title: 'Future task', priority: 'medium', dueDate: getDateOffset(3) }, {});
+
+		const result = await listToday.handler({
+			includeOverdue: false,
+			includeCompleted: false,
+			sortBy: 'priority',
+			sortOrder: 'desc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.total).toBe(0);
+		expect(result.alternatives).toBeDefined();
+		expect(result.alternatives?.length).toBeGreaterThan(0);
+		expect(result.alternatives?.[0].reason).toContain('upcoming');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// todo-list-upcoming
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('todo-list-upcoming', () => {
+	it('returns empty result when no upcoming todos', async () => {
+		const result = await listUpcoming.handler({
+			days: 7,
+			includeCompleted: false,
+			sortBy: 'dueDate',
+			sortOrder: 'asc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.todos).toHaveLength(0);
+		expect(result.data?.total).toBe(0);
+		expect(result.reasoning).toContain('No upcoming');
+	});
+
+	it('returns todos within the specified days', async () => {
+		// Create todos at various future dates
+		const today = new Date();
+		today.setHours(14, 0, 0, 0);
+		await createTodo.handler({ title: 'Due today', priority: 'high', dueDate: today.toISOString() }, {});
+		await createTodo.handler({ title: 'Due in 3 days', priority: 'medium', dueDate: getDateOffset(3) }, {});
+		await createTodo.handler({ title: 'Due in 10 days', priority: 'low', dueDate: getDateOffset(10) }, {});
+
+		const result = await listUpcoming.handler({
+			days: 7,
+			includeCompleted: false,
+			sortBy: 'dueDate',
+			sortOrder: 'asc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		// Should include today and 3 days, but not 10 days
+		expect(result.data?.total).toBe(2);
+		expect(result.data?.daysAhead).toBe(7);
+	});
+
+	it('calculates breakdown correctly', async () => {
+		const today = new Date();
+		today.setHours(14, 0, 0, 0);
+		const tomorrow = new Date();
+		tomorrow.setDate(tomorrow.getDate() + 1);
+		tomorrow.setHours(14, 0, 0, 0);
+
+		await createTodo.handler({ title: 'Today 1', priority: 'high', dueDate: today.toISOString() }, {});
+		await createTodo.handler({ title: 'Today 2', priority: 'medium', dueDate: today.toISOString() }, {});
+		await createTodo.handler({ title: 'Tomorrow', priority: 'low', dueDate: tomorrow.toISOString() }, {});
+
+		const result = await listUpcoming.handler({
+			days: 7,
+			includeCompleted: false,
+			sortBy: 'dueDate',
+			sortOrder: 'asc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.breakdown.today).toBe(2);
+		expect(result.data?.breakdown.tomorrow).toBe(1);
+	});
+
+	it('filters by priority', async () => {
+		await createTodo.handler({ title: 'High priority', priority: 'high', dueDate: getDateOffset(1) }, {});
+		await createTodo.handler({ title: 'Low priority', priority: 'low', dueDate: getDateOffset(1) }, {});
+
+		const result = await listUpcoming.handler({
+			days: 7,
+			includeCompleted: false,
+			priority: 'high',
+			sortBy: 'dueDate',
+			sortOrder: 'asc',
+			limit: 20,
+			offset: 0,
+		}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.todos).toHaveLength(1);
+		expect(result.data?.todos[0].title).toBe('High priority');
+	});
+
+	it('supports pagination', async () => {
+		// Create multiple upcoming todos
+		for (let i = 1; i <= 5; i++) {
+			await createTodo.handler({
+				title: `Task ${i}`,
+				priority: 'medium',
+				dueDate: getDateOffset(i),
+			}, {});
+		}
+
+		const page1 = await listUpcoming.handler({
+			days: 7,
+			includeCompleted: false,
+			sortBy: 'dueDate',
+			sortOrder: 'asc',
+			limit: 2,
+			offset: 0,
+		}, {});
+
+		const page2 = await listUpcoming.handler({
+			days: 7,
+			includeCompleted: false,
+			sortBy: 'dueDate',
+			sortOrder: 'asc',
+			limit: 2,
+			offset: 2,
+		}, {});
+
+		expect(page1.data?.todos).toHaveLength(2);
+		expect(page1.data?.hasMore).toBe(true);
+		expect(page2.data?.todos).toHaveLength(2);
+		expect(page2.data?.hasMore).toBe(true);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// todo-stats with overdue
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('todo-stats with overdue count', () => {
+	it('counts overdue todos', async () => {
+		// Create overdue todo
+		await createTodo.handler({ title: 'Overdue', priority: 'high', dueDate: getDateOffset(-2) }, {});
+		// Create non-overdue todo
+		await createTodo.handler({ title: 'Future', priority: 'medium', dueDate: getDateOffset(2) }, {});
+		// Create todo without due date
+		await createTodo.handler({ title: 'No date', priority: 'low' }, {});
+
+		const result = await getStats.handler({}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.overdue).toBe(1);
+		expect(result.data?.total).toBe(3);
+	});
+
+	it('does not count completed todos as overdue', async () => {
+		// Create and complete an overdue todo
+		const created = await createTodo.handler({
+			title: 'Completed overdue',
+			priority: 'high',
+			dueDate: getDateOffset(-2),
+		}, {});
+
+		// Toggle to completed using the store directly
+		store.toggle(created.data!.id);
+
+		const result = await getStats.handler({}, {});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.overdue).toBe(0);
+	});
+});

--- a/packages/examples/todo/backends/typescript/src/commands/create.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/create.ts
@@ -11,6 +11,10 @@ const inputSchema = z.object({
 	title: z.string().min(1, 'Title is required').max(200, 'Title too long'),
 	description: z.string().max(1000).optional(),
 	priority: z.enum(['low', 'medium', 'high']).default('medium'),
+	dueDate: z
+		.string()
+		.datetime({ message: 'Due date must be a valid ISO 8601 date-time' })
+		.optional(),
 });
 
 export const createTodo = defineCommand<typeof inputSchema, Todo>({
@@ -28,10 +32,12 @@ export const createTodo = defineCommand<typeof inputSchema, Todo>({
 			title: input.title,
 			description: input.description,
 			priority: input.priority,
+			dueDate: input.dueDate,
 		});
 
+		const dueDateText = input.dueDate ? `, due ${new Date(input.dueDate).toLocaleDateString()}` : '';
 		return success(todo, {
-			reasoning: `Created todo "${todo.title}" with ${input.priority} priority`,
+			reasoning: `Created todo "${todo.title}" with ${input.priority} priority${dueDateText}`,
 			confidence: 1.0,
 		});
 	},

--- a/packages/examples/todo/backends/typescript/src/commands/index.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/index.ts
@@ -22,6 +22,10 @@ export { updateList } from './list-update.js';
 export { deleteList, type ListDeleteResult } from './list-delete.js';
 export { listLists, type ListListResult } from './list-list.js';
 
+// Due date filtering
+export { listToday, type TodayResult } from './list-today.js';
+export { listUpcoming, type UpcomingResult } from './list-upcoming.js';
+
 // Re-export as array for convenience
 import { createTodo } from './create.js';
 import { listTodos } from './list.js';
@@ -39,6 +43,9 @@ import { createList } from './list-create.js';
 import { updateList } from './list-update.js';
 import { deleteList } from './list-delete.js';
 import { listLists } from './list-list.js';
+// Due date filtering
+import { listToday } from './list-today.js';
+import { listUpcoming } from './list-upcoming.js';
 import type { ZodCommandDefinition } from '@afd/server';
 
 /**
@@ -64,4 +71,7 @@ export const allCommands = [
 	updateList,
 	deleteList,
 	listLists,
+	// Due date filtering
+	listToday,
+	listUpcoming,
 ] as unknown as ZodCommandDefinition[];

--- a/packages/examples/todo/backends/typescript/src/commands/list-today.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-today.ts
@@ -1,0 +1,168 @@
+/**
+ * @fileoverview todo-list-today command
+ *
+ * Filters tasks by due date to show items due today.
+ * Part of the Today/Upcoming views feature.
+ */
+
+import { z } from 'zod';
+import { defineCommand, success } from '@afd/server';
+import type { Alternative } from '@afd/core';
+import { store } from '../store/index.js';
+import type { Todo } from '../types.js';
+
+const inputSchema = z.object({
+	includeOverdue: z.boolean().default(true).describe('Include overdue items (past due date)'),
+	includeCompleted: z.boolean().default(false).describe('Include completed items'),
+	sortBy: z.enum(['dueDate', 'priority', 'title', 'createdAt']).default('priority'),
+	sortOrder: z.enum(['asc', 'desc']).default('desc'),
+	limit: z.number().int().min(1).max(100).default(20),
+	offset: z.number().int().min(0).default(0),
+});
+
+export interface TodayResult {
+	todos: Todo[];
+	todayCount: number;
+	overdueCount: number;
+	total: number;
+	hasMore: boolean;
+}
+
+export const listToday = defineCommand<typeof inputSchema, TodayResult>({
+	name: 'todo-list-today',
+	description: 'List todos due today, optionally including overdue items',
+	category: 'todo',
+	tags: ['todo', 'list', 'read', 'today', 'due-date', 'filter'],
+	mutation: false,
+	version: '1.0.0',
+	input: inputSchema,
+
+	async handler(input) {
+		const now = new Date();
+		const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+		const endOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+
+		// Get todos due today
+		const todayTodos = store.list({
+			completed: input.includeCompleted ? undefined : false,
+			dueBefore: endOfToday.toISOString(),
+			dueAfter: startOfToday.toISOString(),
+			sortBy: input.sortBy,
+			sortOrder: input.sortOrder,
+		});
+
+		// Get overdue todos (due before today and not completed)
+		const overdueTodos = input.includeOverdue
+			? store.list({
+					completed: false,
+					dueBefore: startOfToday.toISOString(),
+					sortBy: input.sortBy,
+					sortOrder: input.sortOrder,
+				})
+			: [];
+
+		// Combine and sort
+		let combinedTodos = [...overdueTodos, ...todayTodos];
+
+		// Sort combined results
+		const priorityOrder: Record<string, number> = { high: 3, medium: 2, low: 1 };
+		combinedTodos.sort((a, b) => {
+			let comparison = 0;
+			switch (input.sortBy) {
+				case 'priority':
+					comparison = (priorityOrder[a.priority] ?? 0) - (priorityOrder[b.priority] ?? 0);
+					break;
+				case 'title':
+					comparison = a.title.localeCompare(b.title);
+					break;
+				case 'dueDate':
+					if (!a.dueDate && !b.dueDate) comparison = 0;
+					else if (!a.dueDate) comparison = 1;
+					else if (!b.dueDate) comparison = -1;
+					else comparison = a.dueDate.localeCompare(b.dueDate);
+					break;
+				case 'createdAt':
+				default:
+					comparison = a.createdAt.localeCompare(b.createdAt);
+			}
+			return input.sortOrder === 'asc' ? comparison : -comparison;
+		});
+
+		const total = combinedTodos.length;
+		const todayCount = todayTodos.length;
+		const overdueCount = overdueTodos.length;
+
+		// Apply pagination
+		const paginatedTodos = combinedTodos.slice(input.offset, input.offset + input.limit);
+		const hasMore = input.offset + paginatedTodos.length < total;
+
+		// Build reasoning
+		const parts: string[] = [];
+		if (todayCount > 0) {
+			parts.push(`${todayCount} due today`);
+		}
+		if (overdueCount > 0) {
+			parts.push(`${overdueCount} overdue`);
+		}
+		if (parts.length === 0) {
+			parts.push('No tasks due today');
+		}
+
+		// Build alternatives
+		const alternatives: Alternative<TodayResult>[] = [];
+
+		// Offer to view upcoming if no tasks today
+		if (total === 0) {
+			const upcomingTodos = store.list({
+				completed: false,
+				dueAfter: endOfToday.toISOString(),
+				sortBy: 'dueDate',
+				sortOrder: 'asc',
+				limit: input.limit,
+			});
+			if (upcomingTodos.length > 0) {
+				alternatives.push({
+					data: {
+						todos: upcomingTodos,
+						todayCount: 0,
+						overdueCount: 0,
+						total: upcomingTodos.length,
+						hasMore: false,
+					},
+					reason: `View ${upcomingTodos.length} upcoming todos instead`,
+					confidence: 0.8,
+				});
+			}
+		}
+
+		// Offer to exclude overdue if there are many
+		if (input.includeOverdue && overdueCount > 3) {
+			alternatives.push({
+				data: {
+					todos: todayTodos.slice(input.offset, input.offset + input.limit),
+					todayCount,
+					overdueCount: 0,
+					total: todayCount,
+					hasMore: input.offset + input.limit < todayCount,
+				},
+				reason: `View only today's ${todayCount} todos (exclude ${overdueCount} overdue)`,
+				confidence: 0.7,
+			});
+		}
+
+		return success(
+			{
+				todos: paginatedTodos,
+				todayCount,
+				overdueCount,
+				total,
+				hasMore,
+			},
+			{
+				reasoning: parts.join(', '),
+				confidence: 1.0,
+				alternatives: alternatives.length > 0 ? alternatives : undefined,
+			}
+		);
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/list-upcoming.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-upcoming.ts
@@ -1,0 +1,165 @@
+/**
+ * @fileoverview todo-list-upcoming command
+ *
+ * Filters tasks by due date to show items due in the future.
+ * Part of the Today/Upcoming views feature.
+ */
+
+import { z } from 'zod';
+import { defineCommand, success } from '@afd/server';
+import type { Alternative } from '@afd/core';
+import { store } from '../store/index.js';
+import type { Todo } from '../types.js';
+
+const inputSchema = z.object({
+	days: z.number().int().min(1).max(365).default(7).describe('Number of days to look ahead'),
+	includeCompleted: z.boolean().default(false).describe('Include completed items'),
+	priority: z.enum(['low', 'medium', 'high']).optional().describe('Filter by priority'),
+	sortBy: z.enum(['dueDate', 'priority', 'title', 'createdAt']).default('dueDate'),
+	sortOrder: z.enum(['asc', 'desc']).default('asc'),
+	limit: z.number().int().min(1).max(100).default(20),
+	offset: z.number().int().min(0).default(0),
+});
+
+export interface UpcomingResult {
+	todos: Todo[];
+	total: number;
+	hasMore: boolean;
+	daysAhead: number;
+	/** Breakdown by time period */
+	breakdown: {
+		today: number;
+		tomorrow: number;
+		thisWeek: number;
+		later: number;
+	};
+}
+
+export const listUpcoming = defineCommand<typeof inputSchema, UpcomingResult>({
+	name: 'todo-list-upcoming',
+	description: 'List todos due in the upcoming days',
+	category: 'todo',
+	tags: ['todo', 'list', 'read', 'upcoming', 'due-date', 'filter'],
+	mutation: false,
+	version: '1.0.0',
+	input: inputSchema,
+
+	async handler(input) {
+		const now = new Date();
+		const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+		const endOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+		const endOfTomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 23, 59, 59, 999);
+		const endOfWeek = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 7, 23, 59, 59, 999);
+		const endOfRange = new Date(now.getFullYear(), now.getMonth(), now.getDate() + input.days, 23, 59, 59, 999);
+
+		// Get all upcoming todos within the range
+		const allUpcoming = store.list({
+			completed: input.includeCompleted ? undefined : false,
+			priority: input.priority,
+			dueAfter: startOfToday.toISOString(),
+			dueBefore: endOfRange.toISOString(),
+			sortBy: input.sortBy,
+			sortOrder: input.sortOrder,
+		});
+
+		// Calculate breakdown
+		const breakdown = {
+			today: 0,
+			tomorrow: 0,
+			thisWeek: 0,
+			later: 0,
+		};
+
+		for (const todo of allUpcoming) {
+			if (!todo.dueDate) continue;
+			const dueDate = new Date(todo.dueDate);
+
+			if (dueDate <= endOfToday) {
+				breakdown.today++;
+			} else if (dueDate <= endOfTomorrow) {
+				breakdown.tomorrow++;
+			} else if (dueDate <= endOfWeek) {
+				breakdown.thisWeek++;
+			} else {
+				breakdown.later++;
+			}
+		}
+
+		const total = allUpcoming.length;
+
+		// Apply pagination
+		const paginatedTodos = allUpcoming.slice(input.offset, input.offset + input.limit);
+		const hasMore = input.offset + paginatedTodos.length < total;
+
+		// Build reasoning
+		const parts: string[] = [];
+		if (total > 0) {
+			parts.push(`${total} upcoming in next ${input.days} days`);
+			if (breakdown.today > 0) parts.push(`${breakdown.today} today`);
+			if (breakdown.tomorrow > 0) parts.push(`${breakdown.tomorrow} tomorrow`);
+		} else {
+			parts.push(`No upcoming tasks in the next ${input.days} days`);
+		}
+
+		// Build alternatives
+		const alternatives: Alternative<UpcomingResult>[] = [];
+
+		// Offer different time ranges
+		if (input.days === 7 && total < 5) {
+			// Offer to look further ahead
+			const longerRange = store.list({
+				completed: false,
+				dueAfter: startOfToday.toISOString(),
+				dueBefore: new Date(now.getFullYear(), now.getMonth(), now.getDate() + 30).toISOString(),
+				sortBy: 'dueDate',
+				sortOrder: 'asc',
+			});
+			if (longerRange.length > total) {
+				alternatives.push({
+					data: {
+						todos: longerRange.slice(0, input.limit),
+						total: longerRange.length,
+						hasMore: longerRange.length > input.limit,
+						daysAhead: 30,
+						breakdown: { today: 0, tomorrow: 0, thisWeek: 0, later: longerRange.length },
+					},
+					reason: `View ${longerRange.length} todos in next 30 days`,
+					confidence: 0.7,
+				});
+			}
+		}
+
+		// Offer to filter by high priority
+		if (!input.priority && total > 10) {
+			const highPriority = allUpcoming.filter((t) => t.priority === 'high');
+			if (highPriority.length > 0 && highPriority.length < total) {
+				alternatives.push({
+					data: {
+						todos: highPriority.slice(0, input.limit),
+						total: highPriority.length,
+						hasMore: highPriority.length > input.limit,
+						daysAhead: input.days,
+						breakdown: { today: 0, tomorrow: 0, thisWeek: 0, later: highPriority.length },
+					},
+					reason: `View ${highPriority.length} high priority upcoming todos only`,
+					confidence: 0.6,
+				});
+			}
+		}
+
+		return success(
+			{
+				todos: paginatedTodos,
+				total,
+				hasMore,
+				daysAhead: input.days,
+				breakdown,
+			},
+			{
+				reasoning: parts.join(', '),
+				confidence: 1.0,
+				alternatives: alternatives.length > 0 ? alternatives : undefined,
+			}
+		);
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/store/file.ts
+++ b/packages/examples/todo/backends/typescript/src/store/file.ts
@@ -296,11 +296,16 @@ export class FileStore {
     const allTodos = Array.from(todos.values());
     const completed = allTodos.filter((t) => t.completed).length;
     const pending = allTodos.length - completed;
+    const currentTime = new Date();
+    const overdue = allTodos.filter(
+      (t) => t.dueDate && !t.completed && new Date(t.dueDate) < currentTime
+    ).length;
 
     return {
       total: allTodos.length,
       completed,
       pending,
+      overdue,
       byPriority: {
         low: allTodos.filter((t) => t.priority === "low").length,
         medium: allTodos.filter((t) => t.priority === "medium").length,

--- a/packages/examples/todo/backends/typescript/src/store/index.ts
+++ b/packages/examples/todo/backends/typescript/src/store/index.ts
@@ -9,7 +9,7 @@
  * Use "memory" for testing or isolated instances.
  */
 
-import { TodoStore } from "./memory.js";
+import { TodoStore, memoryStore } from "./memory.js";
 import { FileStore } from "./file.js";
 
 // Store type from environment (default: file for shared storage)
@@ -29,7 +29,8 @@ export type Store = TodoStore | FileStore;
 export function createStore(): Store {
   if (STORE_TYPE === "memory") {
     console.error("[Store] Using in-memory storage (isolated per process)");
-    return new TodoStore();
+    // Use the singleton from memory.ts to ensure tests and commands share the same store
+    return memoryStore;
   }
 
   const store = new FileStore(STORE_PATH);

--- a/packages/examples/todo/backends/typescript/src/types.ts
+++ b/packages/examples/todo/backends/typescript/src/types.ts
@@ -26,6 +26,9 @@ export interface Todo {
 	/** Whether the todo is completed */
 	completed: boolean;
 
+	/** Due date (ISO 8601 date-time) */
+	dueDate?: string;
+
 	/** Creation timestamp */
 	createdAt: string;
 
@@ -48,6 +51,9 @@ export interface TodoStats {
 
 	/** Number of pending todos */
 	pending: number;
+
+	/** Number of overdue todos */
+	overdue: number;
 
 	/** Breakdown by priority */
 	byPriority: {
@@ -73,8 +79,17 @@ export interface TodoFilter {
 	/** Search in title/description */
 	search?: string;
 
+	/** Filter todos due before this date (ISO 8601) */
+	dueBefore?: string;
+
+	/** Filter todos due after this date (ISO 8601) */
+	dueAfter?: string;
+
+	/** Filter by overdue status (due date passed and not completed) */
+	overdue?: boolean;
+
 	/** Sort field */
-	sortBy?: 'createdAt' | 'updatedAt' | 'priority' | 'title';
+	sortBy?: 'createdAt' | 'updatedAt' | 'priority' | 'title' | 'dueDate';
 
 	/** Sort direction */
 	sortOrder?: 'asc' | 'desc';

--- a/packages/examples/todo/backends/typescript/vitest.config.ts
+++ b/packages/examples/todo/backends/typescript/vitest.config.ts
@@ -1,9 +1,23 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    passWithNoTests: true,
-  },
+	resolve: {
+		alias: {
+			'@afd/server': resolve(__dirname, '../../../../server/src/index.ts'),
+			'@afd/core': resolve(__dirname, '../../../../core/src/index.ts'),
+		},
+	},
+	test: {
+		globals: true,
+		environment: 'node',
+		passWithNoTests: true,
+		env: {
+			TODO_STORE_TYPE: 'memory',
+		},
+	},
 });


### PR DESCRIPTION
## Summary
- Add `dueDate` field to `todo-create` and `todo-update` commands
- Add `todo-list-today` command for viewing today's tasks with optional overdue inclusion
- Add `todo-list-upcoming` command for viewing upcoming tasks by days with breakdown
- Extend `todo-list` with `dueBefore`, `dueAfter`, and `overdue` filters
- Add `sortBy: 'dueDate'` option to `todo-list`
- Add overdue count to `todo-stats`
- Add comprehensive tests for due date filtering (19 tests, 430 lines)

## Test plan
- [x] All 135 tests pass (`pnpm test` in todo-ts backend)
- [x] New due-date.test.ts covers create, update, list, list-today, list-upcoming, and stats
- [x] Tests cover edge cases: empty results, pagination, clearing due dates, overdue handling

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)