### PR TITLE
feat(todo-ts): implement numeric priority levels (0-3)

### DIFF
--- a/packages/examples/todo/backends/typescript/src/commands/__tests__/batch.test.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/__tests__/batch.test.ts
@@ -29,9 +29,9 @@ describe('todo-createBatch', () => {
 		const result = await createBatch.handler(
 			{
 				todos: [
-					{ title: 'Task 1', priority: 'high' },
-					{ title: 'Task 2', priority: 'medium' },
-					{ title: 'Task 3', priority: 'low' },
+					{ title: 'Task 1', priority: 3 },
+					{ title: 'Task 2', priority: 2 },
+					{ title: 'Task 3', priority: 1 },
 				],
 			},
 			{}
@@ -51,16 +51,16 @@ describe('todo-createBatch', () => {
 		const result = await createBatch.handler(
 			{
 				todos: [
-					{ title: 'High priority', priority: 'high' },
-					{ title: 'Low priority', priority: 'low' },
+					{ title: 'High priority', priority: 3 },
+					{ title: 'Low priority', priority: 1 },
 				],
 			},
 			{}
 		);
 
 		expect(result.success).toBe(true);
-		expect(result.data?.succeeded[0].priority).toBe('high');
-		expect(result.data?.succeeded[1].priority).toBe('low');
+		expect(result.data?.succeeded[0].priority).toBe(3);
+		expect(result.data?.succeeded[1].priority).toBe(1);
 	});
 
 	it('defaults priority to medium', async () => {
@@ -72,13 +72,13 @@ describe('todo-createBatch', () => {
 		);
 
 		expect(result.success).toBe(true);
-		expect(result.data?.succeeded[0].priority).toBe('medium');
+		expect(result.data?.succeeded[0].priority).toBe(2);
 	});
 
 	it('includes description when provided', async () => {
 		const result = await createBatch.handler(
 			{
-				todos: [{ title: 'With description', description: 'Test description', priority: 'medium' }],
+				todos: [{ title: 'With description', description: 'Test description', priority: 2 }],
 			},
 			{}
 		);
@@ -90,7 +90,7 @@ describe('todo-createBatch', () => {
 	it('includes reasoning for full success', async () => {
 		const result = await createBatch.handler(
 			{
-				todos: [{ title: 'Task 1', priority: 'medium' }, { title: 'Task 2', priority: 'medium' }],
+				todos: [{ title: 'Task 1', priority: 2 }, { title: 'Task 2', priority: 2 }],
 			},
 			{}
 		);
@@ -102,8 +102,8 @@ describe('todo-createBatch', () => {
 		await createBatch.handler(
 			{
 				todos: [
-					{ title: 'Batch 1', priority: 'high' },
-					{ title: 'Batch 2', priority: 'medium' },
+					{ title: 'Batch 1', priority: 3 },
+					{ title: 'Batch 2', priority: 2 },
 				],
 			},
 			{}
@@ -130,9 +130,9 @@ describe('todo-createBatch', () => {
 describe('todo-deleteBatch', () => {
 	it('deletes multiple todos successfully', async () => {
 		// Create some todos first
-		const t1 = await createTodo.handler({ title: 'Delete 1', priority: 'medium' }, {});
-		const t2 = await createTodo.handler({ title: 'Delete 2', priority: 'medium' }, {});
-		const t3 = await createTodo.handler({ title: 'Keep', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Delete 1', priority: 2 }, {});
+		const t2 = await createTodo.handler({ title: 'Delete 2', priority: 2 }, {});
+		const t3 = await createTodo.handler({ title: 'Keep', priority: 2 }, {});
 
 		const result = await deleteBatch.handler(
 			{
@@ -162,7 +162,7 @@ describe('todo-deleteBatch', () => {
 	});
 
 	it('handles partial failure with nonexistent IDs', async () => {
-		const t1 = await createTodo.handler({ title: 'Real', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Real', priority: 2 }, {});
 
 		const result = await deleteBatch.handler(
 			{
@@ -180,7 +180,7 @@ describe('todo-deleteBatch', () => {
 	});
 
 	it('includes PARTIAL_SUCCESS warning for mixed results', async () => {
-		const t1 = await createTodo.handler({ title: 'Real', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Real', priority: 2 }, {});
 
 		const result = await deleteBatch.handler(
 			{
@@ -195,7 +195,7 @@ describe('todo-deleteBatch', () => {
 	});
 
 	it('includes DESTRUCTIVE_BATCH warning', async () => {
-		const t1 = await createTodo.handler({ title: 'Delete me', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Delete me', priority: 2 }, {});
 
 		const result = await deleteBatch.handler(
 			{
@@ -243,8 +243,8 @@ describe('todo-deleteBatch', () => {
 
 describe('todo-toggleBatch', () => {
 	it('toggles multiple todos', async () => {
-		const t1 = await createTodo.handler({ title: 'Toggle 1', priority: 'medium' }, {});
-		const t2 = await createTodo.handler({ title: 'Toggle 2', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Toggle 1', priority: 2 }, {});
+		const t2 = await createTodo.handler({ title: 'Toggle 2', priority: 2 }, {});
 
 		const result = await toggleBatch.handler(
 			{
@@ -261,8 +261,8 @@ describe('todo-toggleBatch', () => {
 	});
 
 	it('sets all to completed with completed=true', async () => {
-		const t1 = await createTodo.handler({ title: 'Task 1', priority: 'medium' }, {});
-		const t2 = await createTodo.handler({ title: 'Task 2', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Task 1', priority: 2 }, {});
+		const t2 = await createTodo.handler({ title: 'Task 2', priority: 2 }, {});
 
 		const result = await toggleBatch.handler(
 			{
@@ -279,8 +279,8 @@ describe('todo-toggleBatch', () => {
 
 	it('sets all to incomplete with completed=false', async () => {
 		// Create and complete todos first
-		const t1 = await createTodo.handler({ title: 'Task 1', priority: 'medium' }, {});
-		const t2 = await createTodo.handler({ title: 'Task 2', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Task 1', priority: 2 }, {});
+		const t2 = await createTodo.handler({ title: 'Task 2', priority: 2 }, {});
 
 		// Mark them complete
 		await toggleBatch.handler({ ids: [t1.data!.id, t2.data!.id] }, {});
@@ -300,8 +300,8 @@ describe('todo-toggleBatch', () => {
 	});
 
 	it('handles mixed existing states in toggle mode', async () => {
-		const t1 = await createTodo.handler({ title: 'Task 1', priority: 'medium' }, {});
-		const t2 = await createTodo.handler({ title: 'Task 2', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Task 1', priority: 2 }, {});
+		const t2 = await createTodo.handler({ title: 'Task 2', priority: 2 }, {});
 
 		// Complete just t1
 		await toggleBatch.handler({ ids: [t1.data!.id], completed: true }, {});
@@ -322,7 +322,7 @@ describe('todo-toggleBatch', () => {
 	});
 
 	it('handles partial failure with nonexistent IDs', async () => {
-		const t1 = await createTodo.handler({ title: 'Real', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Real', priority: 2 }, {});
 
 		const result = await toggleBatch.handler(
 			{
@@ -338,7 +338,7 @@ describe('todo-toggleBatch', () => {
 	});
 
 	it('includes PARTIAL_SUCCESS warning for mixed results', async () => {
-		const t1 = await createTodo.handler({ title: 'Real', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Real', priority: 2 }, {});
 
 		const result = await toggleBatch.handler(
 			{
@@ -372,7 +372,7 @@ describe('todo-toggleBatch', () => {
 
 describe('Batch AFD Compliance', () => {
 	it('batch commands return valid CommandResult structure', async () => {
-		const createResult = await createBatch.handler({ todos: [{ title: 'Test', priority: 'medium' }] }, {});
+		const createResult = await createBatch.handler({ todos: [{ title: 'Test', priority: 2 }] }, {});
 		const toggleResult = await toggleBatch.handler({ ids: [createResult.data!.succeeded[0].id] }, {});
 		const deleteResult = await deleteBatch.handler({ ids: [createResult.data!.succeeded[0].id] }, {});
 
@@ -386,7 +386,7 @@ describe('Batch AFD Compliance', () => {
 
 	it('batch results include summary statistics', async () => {
 		const result = await createBatch.handler(
-			{ todos: [{ title: 'Task 1', priority: 'medium' }, { title: 'Task 2', priority: 'medium' }] },
+			{ todos: [{ title: 'Task 1', priority: 2 }, { title: 'Task 2', priority: 2 }] },
 			{}
 		);
 
@@ -397,7 +397,7 @@ describe('Batch AFD Compliance', () => {
 	});
 
 	it('confidence reflects success rate', async () => {
-		const t1 = await createTodo.handler({ title: 'Real', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Real', priority: 2 }, {});
 
 		// 1 success, 1 failure = 0.5 confidence
 		const result = await deleteBatch.handler({ ids: [t1.data!.id, 'fake'] }, {});

--- a/packages/examples/todo/backends/typescript/src/commands/__tests__/commands.test.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/__tests__/commands.test.ts
@@ -27,32 +27,32 @@ beforeEach(() => {
 
 describe('todo-create', () => {
 	it('creates a todo with required fields', async () => {
-		const result = await createTodo.handler({ title: 'Test todo', priority: 'medium' }, {});
+		const result = await createTodo.handler({ title: 'Test todo', priority: 2 }, {});
 
 		expect(result.success).toBe(true);
 		expect(result.data?.title).toBe('Test todo');
-		expect(result.data?.priority).toBe('medium');
+		expect(result.data?.priority).toBe(2);
 		expect(result.data?.completed).toBe(false);
 		expect(result.data?.id).toBeDefined();
 		expect(result.data?.createdAt).toBeDefined();
 	});
 
 	it('creates a todo with high priority', async () => {
-		const result = await createTodo.handler({ title: 'Urgent', priority: 'high' }, {});
+		const result = await createTodo.handler({ title: 'Urgent', priority: 3 }, {});
 
 		expect(result.success).toBe(true);
-		expect(result.data?.priority).toBe('high');
-		expect(result.reasoning).toContain('high priority');
+		expect(result.data?.priority).toBe(3);
+		expect(result.reasoning).toContain('high');
 	});
 
 	it('returns confidence of 1.0', async () => {
-		const result = await createTodo.handler({ title: 'Test', priority: 'low' }, {});
+		const result = await createTodo.handler({ title: 'Test', priority: 1 }, {});
 
 		expect(result.confidence).toBe(1.0);
 	});
 
 	it('includes reasoning', async () => {
-		const result = await createTodo.handler({ title: 'My Task', priority: 'medium' }, {});
+		const result = await createTodo.handler({ title: 'My Task', priority: 2 }, {});
 
 		expect(result.reasoning).toContain('My Task');
 		expect(result.reasoning).toContain('medium');
@@ -66,9 +66,9 @@ describe('todo-create', () => {
 describe('todo-list', () => {
 	beforeEach(async () => {
 		// Create some test todos
-		await createTodo.handler({ title: 'Todo 1', priority: 'high' }, {});
-		await createTodo.handler({ title: 'Todo 2', priority: 'medium' }, {});
-		await createTodo.handler({ title: 'Todo 3', priority: 'low' }, {});
+		await createTodo.handler({ title: 'Todo 1', priority: 3 }, {});
+		await createTodo.handler({ title: 'Todo 2', priority: 2 }, {});
+		await createTodo.handler({ title: 'Todo 3', priority: 1 }, {});
 	});
 
 	it('lists all todos', async () => {
@@ -87,7 +87,7 @@ describe('todo-list', () => {
 
 	it('filters by priority', async () => {
 		const result = await listTodos.handler({
-			priority: 'high',
+			priority: 3,
 			sortBy: 'createdAt',
 			sortOrder: 'desc',
 			limit: 20,
@@ -96,7 +96,7 @@ describe('todo-list', () => {
 
 		expect(result.success).toBe(true);
 		expect(result.data?.todos).toHaveLength(1);
-		expect(result.data?.todos[0].priority).toBe('high');
+		expect(result.data?.todos[0].priority).toBe(3);
 	});
 
 	it('filters by completion status', async () => {
@@ -168,7 +168,7 @@ describe('todo-list', () => {
 
 describe('todo-get', () => {
 	it('gets a todo by ID', async () => {
-		const created = await createTodo.handler({ title: 'Find me', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Find me', priority: 2 }, {});
 		const result = await getTodo.handler({ id: created.data!.id }, {});
 
 		expect(result.success).toBe(true);
@@ -190,7 +190,7 @@ describe('todo-get', () => {
 
 describe('todo-update', () => {
 	it('updates todo title', async () => {
-		const created = await createTodo.handler({ title: 'Original', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Original', priority: 2 }, {});
 		
 		// Small delay to ensure updatedAt differs
 		await new Promise(resolve => setTimeout(resolve, 5));
@@ -207,14 +207,14 @@ describe('todo-update', () => {
 	});
 
 	it('updates todo priority', async () => {
-		const created = await createTodo.handler({ title: 'Test', priority: 'low' }, {});
+		const created = await createTodo.handler({ title: 'Test', priority: 1 }, {});
 		const result = await updateTodo.handler({
 			id: created.data!.id,
-			priority: 'high',
+			priority: 3,
 		}, {});
 
 		expect(result.success).toBe(true);
-		expect(result.data?.priority).toBe('high');
+		expect(result.data?.priority).toBe(3);
 	});
 
 	it('returns NOT_FOUND for missing todo', async () => {
@@ -228,7 +228,7 @@ describe('todo-update', () => {
 	});
 
 	it('returns NO_CHANGES when nothing to update', async () => {
-		const created = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Test', priority: 2 }, {});
 		const result = await updateTodo.handler({ id: created.data!.id }, {});
 
 		expect(result.success).toBe(false);
@@ -242,7 +242,7 @@ describe('todo-update', () => {
 
 describe('todo-toggle', () => {
 	it('marks todo as completed', async () => {
-		const created = await createTodo.handler({ title: 'Toggle me', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Toggle me', priority: 2 }, {});
 		const result = await toggleTodo.handler({ id: created.data!.id }, {});
 
 		expect(result.success).toBe(true);
@@ -252,7 +252,7 @@ describe('todo-toggle', () => {
 	});
 
 	it('marks todo as pending when toggled again', async () => {
-		const created = await createTodo.handler({ title: 'Toggle me', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Toggle me', priority: 2 }, {});
 		await toggleTodo.handler({ id: created.data!.id }, {});
 		const result = await toggleTodo.handler({ id: created.data!.id }, {});
 
@@ -276,7 +276,7 @@ describe('todo-toggle', () => {
 
 describe('todo-delete', () => {
 	it('deletes a todo', async () => {
-		const created = await createTodo.handler({ title: 'Delete me', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Delete me', priority: 2 }, {});
 		const result = await deleteTodo.handler({ id: created.data!.id }, {});
 
 		expect(result.success).toBe(true);
@@ -288,7 +288,7 @@ describe('todo-delete', () => {
 	});
 
 	it('includes warning about permanence', async () => {
-		const created = await createTodo.handler({ title: 'Delete me', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Delete me', priority: 2 }, {});
 		const result = await deleteTodo.handler({ id: created.data!.id }, {});
 
 		expect(result.warnings).toBeDefined();
@@ -310,9 +310,9 @@ describe('todo-delete', () => {
 describe('todo-clear', () => {
 	it('clears completed todos', async () => {
 		// Create and complete some todos
-		const t1 = await createTodo.handler({ title: 'Todo 1', priority: 'medium' }, {});
-		const t2 = await createTodo.handler({ title: 'Todo 2', priority: 'medium' }, {});
-		await createTodo.handler({ title: 'Todo 3', priority: 'medium' }, {});
+		const t1 = await createTodo.handler({ title: 'Todo 1', priority: 2 }, {});
+		const t2 = await createTodo.handler({ title: 'Todo 2', priority: 2 }, {});
+		await createTodo.handler({ title: 'Todo 3', priority: 2 }, {});
 
 		await toggleTodo.handler({ id: t1.data!.id }, {});
 		await toggleTodo.handler({ id: t2.data!.id }, {});
@@ -333,7 +333,7 @@ describe('todo-clear', () => {
 	});
 
 	it('returns 0 when nothing to clear', async () => {
-		await createTodo.handler({ title: 'Pending', priority: 'medium' }, {});
+		await createTodo.handler({ title: 'Pending', priority: 2 }, {});
 
 		const result = await clearCompleted.handler({}, {});
 
@@ -359,10 +359,10 @@ describe('todo-stats', () => {
 	});
 
 	it('calculates stats correctly', async () => {
-		await createTodo.handler({ title: 'High 1', priority: 'high' }, {});
-		await createTodo.handler({ title: 'High 2', priority: 'high' }, {});
-		await createTodo.handler({ title: 'Medium', priority: 'medium' }, {});
-		const t4 = await createTodo.handler({ title: 'Low', priority: 'low' }, {});
+		await createTodo.handler({ title: 'High 1', priority: 3 }, {});
+		await createTodo.handler({ title: 'High 2', priority: 3 }, {});
+		await createTodo.handler({ title: 'Medium', priority: 2 }, {});
+		const t4 = await createTodo.handler({ title: 'Low', priority: 1 }, {});
 
 		// Complete one
 		await toggleTodo.handler({ id: t4.data!.id }, {});
@@ -373,13 +373,13 @@ describe('todo-stats', () => {
 		expect(result.data?.completed).toBe(1);
 		expect(result.data?.pending).toBe(3);
 		expect(result.data?.completionRate).toBe(0.25);
-		expect(result.data?.byPriority.high).toBe(2);
-		expect(result.data?.byPriority.medium).toBe(1);
-		expect(result.data?.byPriority.low).toBe(1);
+		expect(result.data?.byPriority[3]).toBe(2);
+		expect(result.data?.byPriority[2]).toBe(1);
+		expect(result.data?.byPriority[1]).toBe(1);
 	});
 
 	it('includes reasoning with summary', async () => {
-		await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		await createTodo.handler({ title: 'Test', priority: 2 }, {});
 
 		const result = await getStats.handler({}, {});
 
@@ -394,7 +394,7 @@ describe('todo-stats', () => {
 describe('AFD Compliance', () => {
 	it('all commands return valid CommandResult structure', async () => {
 		const commands = [
-			() => createTodo.handler({ title: 'Test', priority: 'medium' }, {}),
+			() => createTodo.handler({ title: 'Test', priority: 2 }, {}),
 			() => listTodos.handler({ sortBy: 'createdAt', sortOrder: 'desc', limit: 20, offset: 0 }, {}),
 			() => getStats.handler({}, {}),
 		];
@@ -417,7 +417,7 @@ describe('AFD Compliance', () => {
 	});
 
 	it('success results include confidence', async () => {
-		const result = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const result = await createTodo.handler({ title: 'Test', priority: 2 }, {});
 
 		expect(result.success).toBe(true);
 		expect(result.confidence).toBeGreaterThanOrEqual(0);
@@ -425,7 +425,7 @@ describe('AFD Compliance', () => {
 	});
 
 	it('success results include reasoning', async () => {
-		const result = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const result = await createTodo.handler({ title: 'Test', priority: 2 }, {});
 
 		expect(result.success).toBe(true);
 		expect(result.reasoning).toBeDefined();
@@ -441,7 +441,7 @@ describe('AFD Compliance', () => {
 	});
 
 	it('mutation commands include warnings when appropriate', async () => {
-		const created = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Test', priority: 2 }, {});
 		const result = await deleteTodo.handler({ id: created.data!.id }, {});
 
 		expect(result.warnings).toBeDefined();

--- a/packages/examples/todo/backends/typescript/src/commands/__tests__/complete.test.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/__tests__/complete.test.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
 
 describe('todo-complete', () => {
 	it('marks todo as completed', async () => {
-		const created = await createTodo.handler({ title: 'Complete me', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Complete me', priority: 2 }, {});
 		const result = await completeTodo.handler({ id: created.data!.id }, {});
 
 		expect(result.success).toBe(true);
@@ -32,7 +32,7 @@ describe('todo-complete', () => {
 	});
 
 	it('returns ALREADY_COMPLETED for completed todo', async () => {
-		const created = await createTodo.handler({ title: 'Already done', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Already done', priority: 2 }, {});
 		await completeTodo.handler({ id: created.data!.id }, {});
 		const result = await completeTodo.handler({ id: created.data!.id }, {});
 
@@ -50,7 +50,7 @@ describe('todo-complete', () => {
 	});
 
 	it('returns confidence of 1.0', async () => {
-		const created = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Test', priority: 2 }, {});
 		const result = await completeTodo.handler({ id: created.data!.id }, {});
 
 		expect(result.confidence).toBe(1.0);
@@ -63,7 +63,7 @@ describe('todo-complete', () => {
 
 describe('todo-uncomplete', () => {
 	it('marks todo as pending', async () => {
-		const created = await createTodo.handler({ title: 'Uncomplete me', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Uncomplete me', priority: 2 }, {});
 		await completeTodo.handler({ id: created.data!.id }, {});
 		const result = await uncompleteTodo.handler({ id: created.data!.id }, {});
 
@@ -74,7 +74,7 @@ describe('todo-uncomplete', () => {
 	});
 
 	it('returns NOT_COMPLETED for pending todo', async () => {
-		const created = await createTodo.handler({ title: 'Still pending', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Still pending', priority: 2 }, {});
 		const result = await uncompleteTodo.handler({ id: created.data!.id }, {});
 
 		expect(result.success).toBe(false);
@@ -91,7 +91,7 @@ describe('todo-uncomplete', () => {
 	});
 
 	it('returns confidence of 1.0', async () => {
-		const created = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Test', priority: 2 }, {});
 		await completeTodo.handler({ id: created.data!.id }, {});
 		const result = await uncompleteTodo.handler({ id: created.data!.id }, {});
 
@@ -105,7 +105,7 @@ describe('todo-uncomplete', () => {
 
 describe('complete/uncomplete interaction', () => {
 	it('can complete and uncomplete repeatedly', async () => {
-		const created = await createTodo.handler({ title: 'Toggle test', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Toggle test', priority: 2 }, {});
 
 		// Complete
 		let result = await completeTodo.handler({ id: created.data!.id }, {});
@@ -122,7 +122,7 @@ describe('complete/uncomplete interaction', () => {
 	});
 
 	it('updates timestamps correctly', async () => {
-		const created = await createTodo.handler({ title: 'Timestamp test', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Timestamp test', priority: 2 }, {});
 		const originalUpdatedAt = created.data!.updatedAt;
 
 		// Small delay to ensure timestamps differ

--- a/packages/examples/todo/backends/typescript/src/commands/__tests__/due-date.test.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/__tests__/due-date.test.ts
@@ -46,7 +46,7 @@ describe('todo-create with dueDate', () => {
 	it('creates a todo with a due date', async () => {
 		const dueDate = getDateOffset(1);
 		const result = await createTodo.handler(
-			{ title: 'Due tomorrow', priority: 'high', dueDate },
+			{ title: 'Due tomorrow', priority: 3, dueDate },
 			{}
 		);
 
@@ -57,7 +57,7 @@ describe('todo-create with dueDate', () => {
 
 	it('creates a todo without a due date', async () => {
 		const result = await createTodo.handler(
-			{ title: 'No due date', priority: 'medium' },
+			{ title: 'No due date', priority: 2 },
 			{}
 		);
 
@@ -72,7 +72,7 @@ describe('todo-create with dueDate', () => {
 
 describe('todo-update with dueDate', () => {
 	it('updates a todo with a due date', async () => {
-		const created = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Test', priority: 2 }, {});
 		const dueDate = getDateOffset(3);
 
 		const result = await updateTodo.handler(
@@ -88,7 +88,7 @@ describe('todo-update with dueDate', () => {
 	it('clears a due date by setting to null', async () => {
 		const dueDate = getDateOffset(1);
 		const created = await createTodo.handler(
-			{ title: 'Has due date', priority: 'medium', dueDate },
+			{ title: 'Has due date', priority: 2, dueDate },
 			{}
 		);
 
@@ -111,11 +111,11 @@ describe('todo-update with dueDate', () => {
 describe('todo-list with due date filters', () => {
 	beforeEach(async () => {
 		// Create todos with various due dates
-		await createTodo.handler({ title: 'Overdue', priority: 'high', dueDate: getDateOffset(-2) }, {});
-		await createTodo.handler({ title: 'Due today', priority: 'medium', dueDate: new Date().toISOString() }, {});
-		await createTodo.handler({ title: 'Due tomorrow', priority: 'low', dueDate: getDateOffset(1) }, {});
-		await createTodo.handler({ title: 'Due next week', priority: 'medium', dueDate: getDateOffset(7) }, {});
-		await createTodo.handler({ title: 'No due date', priority: 'low' }, {});
+		await createTodo.handler({ title: 'Overdue', priority: 3, dueDate: getDateOffset(-2) }, {});
+		await createTodo.handler({ title: 'Due today', priority: 2, dueDate: new Date().toISOString() }, {});
+		await createTodo.handler({ title: 'Due tomorrow', priority: 1, dueDate: getDateOffset(1) }, {});
+		await createTodo.handler({ title: 'Due next week', priority: 2, dueDate: getDateOffset(7) }, {});
+		await createTodo.handler({ title: 'No due date', priority: 1 }, {});
 	});
 
 	it('filters by dueBefore', async () => {
@@ -205,7 +205,7 @@ describe('todo-list-today', () => {
 		// Create a todo due today
 		const today = new Date();
 		today.setHours(12, 0, 0, 0);
-		await createTodo.handler({ title: 'Due today', priority: 'high', dueDate: today.toISOString() }, {});
+		await createTodo.handler({ title: 'Due today', priority: 3, dueDate: today.toISOString() }, {});
 
 		const result = await listToday.handler({
 			includeOverdue: false,
@@ -223,7 +223,7 @@ describe('todo-list-today', () => {
 
 	it('includes overdue todos when flag is set', async () => {
 		// Create overdue todo
-		await createTodo.handler({ title: 'Overdue task', priority: 'high', dueDate: getDateOffset(-2) }, {});
+		await createTodo.handler({ title: 'Overdue task', priority: 3, dueDate: getDateOffset(-2) }, {});
 
 		const withOverdue = await listToday.handler({
 			includeOverdue: true,
@@ -249,7 +249,7 @@ describe('todo-list-today', () => {
 
 	it('provides alternatives when no tasks today', async () => {
 		// Create a future todo
-		await createTodo.handler({ title: 'Future task', priority: 'medium', dueDate: getDateOffset(3) }, {});
+		await createTodo.handler({ title: 'Future task', priority: 2, dueDate: getDateOffset(3) }, {});
 
 		const result = await listToday.handler({
 			includeOverdue: false,
@@ -293,9 +293,9 @@ describe('todo-list-upcoming', () => {
 		// Create todos at various future dates
 		const today = new Date();
 		today.setHours(14, 0, 0, 0);
-		await createTodo.handler({ title: 'Due today', priority: 'high', dueDate: today.toISOString() }, {});
-		await createTodo.handler({ title: 'Due in 3 days', priority: 'medium', dueDate: getDateOffset(3) }, {});
-		await createTodo.handler({ title: 'Due in 10 days', priority: 'low', dueDate: getDateOffset(10) }, {});
+		await createTodo.handler({ title: 'Due today', priority: 3, dueDate: today.toISOString() }, {});
+		await createTodo.handler({ title: 'Due in 3 days', priority: 2, dueDate: getDateOffset(3) }, {});
+		await createTodo.handler({ title: 'Due in 10 days', priority: 1, dueDate: getDateOffset(10) }, {});
 
 		const result = await listUpcoming.handler({
 			days: 7,
@@ -319,9 +319,9 @@ describe('todo-list-upcoming', () => {
 		tomorrow.setDate(tomorrow.getDate() + 1);
 		tomorrow.setHours(14, 0, 0, 0);
 
-		await createTodo.handler({ title: 'Today 1', priority: 'high', dueDate: today.toISOString() }, {});
-		await createTodo.handler({ title: 'Today 2', priority: 'medium', dueDate: today.toISOString() }, {});
-		await createTodo.handler({ title: 'Tomorrow', priority: 'low', dueDate: tomorrow.toISOString() }, {});
+		await createTodo.handler({ title: 'Today 1', priority: 3, dueDate: today.toISOString() }, {});
+		await createTodo.handler({ title: 'Today 2', priority: 2, dueDate: today.toISOString() }, {});
+		await createTodo.handler({ title: 'Tomorrow', priority: 1, dueDate: tomorrow.toISOString() }, {});
 
 		const result = await listUpcoming.handler({
 			days: 7,
@@ -338,13 +338,13 @@ describe('todo-list-upcoming', () => {
 	});
 
 	it('filters by priority', async () => {
-		await createTodo.handler({ title: 'High priority', priority: 'high', dueDate: getDateOffset(1) }, {});
-		await createTodo.handler({ title: 'Low priority', priority: 'low', dueDate: getDateOffset(1) }, {});
+		await createTodo.handler({ title: 'High priority', priority: 3, dueDate: getDateOffset(1) }, {});
+		await createTodo.handler({ title: 'Low priority', priority: 1, dueDate: getDateOffset(1) }, {});
 
 		const result = await listUpcoming.handler({
 			days: 7,
 			includeCompleted: false,
-			priority: 'high',
+			priority: 3,
 			sortBy: 'dueDate',
 			sortOrder: 'asc',
 			limit: 20,
@@ -361,7 +361,7 @@ describe('todo-list-upcoming', () => {
 		for (let i = 1; i <= 5; i++) {
 			await createTodo.handler({
 				title: `Task ${i}`,
-				priority: 'medium',
+				priority: 2,
 				dueDate: getDateOffset(i),
 			}, {});
 		}
@@ -398,11 +398,11 @@ describe('todo-list-upcoming', () => {
 describe('todo-stats with overdue count', () => {
 	it('counts overdue todos', async () => {
 		// Create overdue todo
-		await createTodo.handler({ title: 'Overdue', priority: 'high', dueDate: getDateOffset(-2) }, {});
+		await createTodo.handler({ title: 'Overdue', priority: 3, dueDate: getDateOffset(-2) }, {});
 		// Create non-overdue todo
-		await createTodo.handler({ title: 'Future', priority: 'medium', dueDate: getDateOffset(2) }, {});
+		await createTodo.handler({ title: 'Future', priority: 2, dueDate: getDateOffset(2) }, {});
 		// Create todo without due date
-		await createTodo.handler({ title: 'No date', priority: 'low' }, {});
+		await createTodo.handler({ title: 'No date', priority: 1 }, {});
 
 		const result = await getStats.handler({}, {});
 
@@ -415,7 +415,7 @@ describe('todo-stats with overdue count', () => {
 		// Create and complete an overdue todo
 		const created = await createTodo.handler({
 			title: 'Completed overdue',
-			priority: 'high',
+			priority: 3,
 			dueDate: getDateOffset(-2),
 		}, {});
 

--- a/packages/examples/todo/backends/typescript/src/commands/__tests__/list-commands.test.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/__tests__/list-commands.test.ts
@@ -46,8 +46,8 @@ describe('list-create', () => {
 
 	it('creates a list with todoIds', async () => {
 		// Create some todos first
-		const todo1 = await createTodo.handler({ title: 'Todo 1', priority: 'medium' }, {});
-		const todo2 = await createTodo.handler({ title: 'Todo 2', priority: 'high' }, {});
+		const todo1 = await createTodo.handler({ title: 'Todo 1', priority: 2 }, {});
+		const todo2 = await createTodo.handler({ title: 'Todo 2', priority: 3 }, {});
 
 		const result = await createList.handler({
 			name: 'Project List',
@@ -73,7 +73,7 @@ describe('list-create', () => {
 	});
 
 	it('includes todo count in reasoning when todoIds provided', async () => {
-		const todo = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const todo = await createTodo.handler({ title: 'Test', priority: 2 }, {});
 		const result = await createList.handler({
 			name: 'With Todos',
 			todoIds: [todo.data!.id],
@@ -201,7 +201,7 @@ describe('list-update', () => {
 	});
 
 	it('updates list todoIds', async () => {
-		const todo = await createTodo.handler({ title: 'New Todo', priority: 'medium' }, {});
+		const todo = await createTodo.handler({ title: 'New Todo', priority: 2 }, {});
 		const created = await createList.handler({ name: 'Test List' }, {});
 
 		const result = await updateList.handler({

--- a/packages/examples/todo/backends/typescript/src/commands/__tests__/performance.test.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/__tests__/performance.test.ts
@@ -84,7 +84,7 @@ async function createBulkTodos(count: number): Promise<string[]> {
 	for (let i = 0; i < count; i++) {
 		const result = await createTodo.handler({
 			title: `Bulk Todo ${i}`,
-			priority: ['low', 'medium', 'high'][i % 3] as 'low' | 'medium' | 'high',
+			priority: [1, 2, 3][i % 3] as 1 | 2 | 3,
 		}, {});
 		if (result.success && result.data) {
 			ids.push(result.data.id);
@@ -127,14 +127,14 @@ afterAll(() => {
 describe('Single Operation Performance', () => {
 	it(`todo-create < ${THRESHOLDS.create}ms`, async () => {
 		const result = await measure('todo-create', THRESHOLDS.create, () =>
-			createTodo.handler({ title: 'Perf test', priority: 'medium' }, {})
+			createTodo.handler({ title: 'Perf test', priority: 2 }, {})
 		);
 
 		expect(result.success).toBe(true);
 	});
 
 	it(`todo-get < ${THRESHOLDS.get}ms`, async () => {
-		const created = await createTodo.handler({ title: 'Find me', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Find me', priority: 2 }, {});
 
 		const result = await measure('todo-get', THRESHOLDS.get, () =>
 			getTodo.handler({ id: created.data!.id }, {})
@@ -144,7 +144,7 @@ describe('Single Operation Performance', () => {
 	});
 
 	it(`todo-update < ${THRESHOLDS.update}ms`, async () => {
-		const created = await createTodo.handler({ title: 'Update me', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Update me', priority: 2 }, {});
 
 		const result = await measure('todo-update', THRESHOLDS.update, () =>
 			updateTodo.handler({ id: created.data!.id, title: 'Updated' }, {})
@@ -154,7 +154,7 @@ describe('Single Operation Performance', () => {
 	});
 
 	it(`todo-toggle < ${THRESHOLDS.toggle}ms`, async () => {
-		const created = await createTodo.handler({ title: 'Toggle me', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Toggle me', priority: 2 }, {});
 
 		const result = await measure('todo-toggle', THRESHOLDS.toggle, () =>
 			toggleTodo.handler({ id: created.data!.id }, {})
@@ -164,7 +164,7 @@ describe('Single Operation Performance', () => {
 	});
 
 	it(`todo-delete < ${THRESHOLDS.delete}ms`, async () => {
-		const created = await createTodo.handler({ title: 'Delete me', priority: 'medium' }, {});
+		const created = await createTodo.handler({ title: 'Delete me', priority: 2 }, {});
 
 		const result = await measure('todo-delete', THRESHOLDS.delete, () =>
 			deleteTodo.handler({ id: created.data!.id }, {})
@@ -201,7 +201,7 @@ describe('Query Performance', () => {
 	it(`todo-list filtered < ${THRESHOLDS.listFiltered}ms`, async () => {
 		const result = await measure('todo-list (filtered)', THRESHOLDS.listFiltered, () =>
 			listTodos.handler({
-				priority: 'high',
+				priority: 3,
 				completed: false,
 				sortBy: 'createdAt',
 				sortOrder: 'desc',
@@ -292,7 +292,7 @@ describe('Latency Percentiles', () => {
 		// Run 50 iterations
 		for (let i = 0; i < 50; i++) {
 			const start = performance.now();
-			await createTodo.handler({ title: `Latency test ${i}`, priority: 'medium' }, {});
+			await createTodo.handler({ title: `Latency test ${i}`, priority: 2 }, {});
 			durations.push(performance.now() - start);
 		}
 
@@ -325,7 +325,7 @@ describe('Latency Percentiles', () => {
 describe('Performance Metadata in Results', () => {
 	it('commands include executionTimeMs in metadata when run through server', async () => {
 		// This is tested at the server level, but we verify the structure here
-		const result = await createTodo.handler({ title: 'Test', priority: 'medium' }, {});
+		const result = await createTodo.handler({ title: 'Test', priority: 2 }, {});
 
 		expect(result.success).toBe(true);
 		// Note: executionTimeMs is added by the server, not the command itself

--- a/packages/examples/todo/backends/typescript/src/commands/__tests__/pipeline.test.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/__tests__/pipeline.test.ts
@@ -42,7 +42,7 @@ describe('Todo Pipeline Integration', () => {
 			// Pipeline: Create todo → Toggle it to complete → Get final state
 			const request: PipelineRequest = {
 				steps: [
-					{ command: 'todo-create', input: { title: 'Pipeline task', priority: 'high' }, as: 'created' },
+					{ command: 'todo-create', input: { title: 'Pipeline task', priority: 3 }, as: 'created' },
 					{ command: 'todo-toggle', input: { id: '$steps.created.id' } },
 					{ command: 'todo-get', input: { id: '$steps.created.id' } },
 				],
@@ -58,7 +58,7 @@ describe('Todo Pipeline Integration', () => {
 			// Final data is the completed todo
 			expect(result.data).toMatchObject({
 				title: 'Pipeline task',
-				priority: 'high',
+				priority: 3,
 				completed: true,
 			});
 
@@ -71,9 +71,9 @@ describe('Todo Pipeline Integration', () => {
 			// Pipeline: Create 3 todos → Toggle one → Get stats
 			const request: PipelineRequest = {
 				steps: [
-					{ command: 'todo-create', input: { title: 'Task 1', priority: 'high' }, as: 'todo1' },
-					{ command: 'todo-create', input: { title: 'Task 2', priority: 'medium' } },
-					{ command: 'todo-create', input: { title: 'Task 3', priority: 'low' } },
+					{ command: 'todo-create', input: { title: 'Task 1', priority: 3 }, as: 'todo1' },
+					{ command: 'todo-create', input: { title: 'Task 2', priority: 2 } },
+					{ command: 'todo-create', input: { title: 'Task 3', priority: 1 } },
 					{ command: 'todo-toggle', input: { id: '$steps.todo1.id' } },
 					{ command: 'todo-stats', input: {} },
 				],
@@ -91,9 +91,9 @@ describe('Todo Pipeline Integration', () => {
 
 		it('lists and clears completed todos', async () => {
 			// Pre-seed some todos
-			await server.execute('todo-create', { title: 'Done 1', priority: 'high' });
-			const t2 = await server.execute('todo-create', { title: 'Done 2', priority: 'medium' });
-			await server.execute('todo-create', { title: 'Pending', priority: 'low' });
+			await server.execute('todo-create', { title: 'Done 1', priority: 3 });
+			const t2 = await server.execute('todo-create', { title: 'Done 2', priority: 2 });
+			await server.execute('todo-create', { title: 'Pending', priority: 1 });
 
 			// Complete one directly
 			await server.execute('todo-toggle', { id: (t2.data as { id: string }).id });
@@ -135,7 +135,7 @@ describe('Todo Pipeline Integration', () => {
 		it('resolves $prev to pass todo between steps', async () => {
 			const request: PipelineRequest = {
 				steps: [
-					{ command: 'todo-create', input: { title: 'Chained', priority: 'medium' } },
+					{ command: 'todo-create', input: { title: 'Chained', priority: 2 } },
 					{ command: 'todo-get', input: { id: '$prev.id' } },
 				],
 			};
@@ -151,8 +151,8 @@ describe('Todo Pipeline Integration', () => {
 		it('resolves $steps.alias for named references', async () => {
 			const request: PipelineRequest = {
 				steps: [
-					{ command: 'todo-create', input: { title: 'Original', priority: 'low' }, as: 'original' },
-					{ command: 'todo-update', input: { id: '$steps.original.id', title: 'Updated via alias', priority: 'high' } },
+					{ command: 'todo-create', input: { title: 'Original', priority: 1 }, as: 'original' },
+					{ command: 'todo-update', input: { id: '$steps.original.id', title: 'Updated via alias', priority: 3 } },
 					{ command: 'todo-get', input: { id: '$steps.original.id' } },
 				],
 			};
@@ -161,7 +161,7 @@ describe('Todo Pipeline Integration', () => {
 
 			expect(result.data).toMatchObject({
 				title: 'Updated via alias',
-				priority: 'high',
+				priority: 3,
 			});
 		});
 	});
@@ -212,7 +212,7 @@ describe('Todo Pipeline Integration', () => {
 		it('skips toggle when todo is already completed', async () => {
 			const request: PipelineRequest = {
 				steps: [
-					{ command: 'todo-create', input: { title: 'Test', priority: 'medium' }, as: 'todo' },
+					{ command: 'todo-create', input: { title: 'Test', priority: 2 }, as: 'todo' },
 					{ command: 'todo-toggle', input: { id: '$steps.todo.id' } }, // Complete it
 					{
 						command: 'todo-toggle',
@@ -235,11 +235,11 @@ describe('Todo Pipeline Integration', () => {
 		it('runs step only when condition is met', async () => {
 			const request: PipelineRequest = {
 				steps: [
-					{ command: 'todo-create', input: { title: 'High priority', priority: 'high' }, as: 'todo' },
+					{ command: 'todo-create', input: { title: 'High priority', priority: 3 }, as: 'todo' },
 					{
 						command: 'todo-update',
 						input: { id: '$steps.todo.id', title: 'URGENT: High priority' },
-						when: { $eq: ['$steps.todo.priority', 'high'] },
+						when: { $eq: ['$steps.todo.priority', 3] },
 					},
 				],
 			};
@@ -261,7 +261,7 @@ describe('Todo Pipeline Integration', () => {
 		it('aggregates reasoning from all steps', async () => {
 			const request: PipelineRequest = {
 				steps: [
-					{ command: 'todo-create', input: { title: 'Task', priority: 'high' } },
+					{ command: 'todo-create', input: { title: 'Task', priority: 3 } },
 					{ command: 'todo-toggle', input: { id: '$prev.id' } },
 					{ command: 'todo-stats', input: {} },
 				],
@@ -278,7 +278,7 @@ describe('Todo Pipeline Integration', () => {
 		it('tracks execution time for each step', async () => {
 			const request: PipelineRequest = {
 				steps: [
-					{ command: 'todo-create', input: { title: 'Timed', priority: 'medium' } },
+					{ command: 'todo-create', input: { title: 'Timed', priority: 2 } },
 					{ command: 'todo-stats', input: {} },
 				],
 			};
@@ -294,7 +294,7 @@ describe('Todo Pipeline Integration', () => {
 			// All todo commands return 1.0 confidence, so pipeline should also be 1.0
 			const request: PipelineRequest = {
 				steps: [
-					{ command: 'todo-create', input: { title: 'Test', priority: 'medium' } },
+					{ command: 'todo-create', input: { title: 'Test', priority: 2 } },
 					{ command: 'todo-stats', input: {} },
 				],
 			};

--- a/packages/examples/todo/backends/typescript/src/commands/create-batch.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/create-batch.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { defineCommand, success } from '@afd/server';
 import type { CommandError } from '@afd/core';
 import { store } from '../store/index.js';
-import type { Todo } from '../types.js';
+import type { Todo, Priority } from '../types.js';
 
 /**
  * Schema for a single todo item in a batch
@@ -17,7 +17,7 @@ import type { Todo } from '../types.js';
 const todoItemSchema = z.object({
 	title: z.string().min(1, 'Title is required').max(200, 'Title too long'),
 	description: z.string().max(1000).optional(),
-	priority: z.enum(['low', 'medium', 'high']).default('medium'),
+	priority: z.number().int().min(0).max(3).default(2) as z.ZodType<Priority, z.ZodTypeDef, Priority>,
 });
 
 const inputSchema = z.object({

--- a/packages/examples/todo/backends/typescript/src/commands/create.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/create.ts
@@ -5,12 +5,13 @@
 import { z } from 'zod';
 import { defineCommand, success } from '@afd/server';
 import { store } from '../store/index.js';
-import type { Todo } from '../types.js';
+import type { Todo, Priority } from '../types.js';
+import { PRIORITY_LABELS } from '../types.js';
 
 const inputSchema = z.object({
 	title: z.string().min(1, 'Title is required').max(200, 'Title too long'),
 	description: z.string().max(1000).optional(),
-	priority: z.enum(['low', 'medium', 'high']).default('medium'),
+	priority: z.number().int().min(0).max(3).default(2) as z.ZodType<Priority, z.ZodTypeDef, Priority>,
 	dueDate: z
 		.string()
 		.datetime({ message: 'Due date must be a valid ISO 8601 date-time' })
@@ -37,7 +38,7 @@ export const createTodo = defineCommand<typeof inputSchema, Todo>({
 
 		const dueDateText = input.dueDate ? `, due ${new Date(input.dueDate).toLocaleDateString()}` : '';
 		return success(todo, {
-			reasoning: `Created todo "${todo.title}" with ${input.priority} priority${dueDateText}`,
+			reasoning: `Created todo "${todo.title}" with ${PRIORITY_LABELS[input.priority]} priority${dueDateText}`,
 			confidence: 1.0,
 		});
 	},

--- a/packages/examples/todo/backends/typescript/src/commands/list-today.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-today.ts
@@ -65,12 +65,11 @@ export const listToday = defineCommand<typeof inputSchema, TodayResult>({
 		let combinedTodos = [...overdueTodos, ...todayTodos];
 
 		// Sort combined results
-		const priorityOrder: Record<string, number> = { high: 3, medium: 2, low: 1 };
 		combinedTodos.sort((a, b) => {
 			let comparison = 0;
 			switch (input.sortBy) {
 				case 'priority':
-					comparison = (priorityOrder[a.priority] ?? 0) - (priorityOrder[b.priority] ?? 0);
+					comparison = a.priority - b.priority;
 					break;
 				case 'title':
 					comparison = a.title.localeCompare(b.title);

--- a/packages/examples/todo/backends/typescript/src/commands/list-upcoming.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-upcoming.ts
@@ -9,12 +9,12 @@ import { z } from 'zod';
 import { defineCommand, success } from '@afd/server';
 import type { Alternative } from '@afd/core';
 import { store } from '../store/index.js';
-import type { Todo } from '../types.js';
+import type { Todo, Priority } from '../types.js';
 
 const inputSchema = z.object({
 	days: z.number().int().min(1).max(365).default(7).describe('Number of days to look ahead'),
 	includeCompleted: z.boolean().default(false).describe('Include completed items'),
-	priority: z.enum(['low', 'medium', 'high']).optional().describe('Filter by priority'),
+	priority: (z.number().int().min(0).max(3) as z.ZodType<Priority, z.ZodTypeDef, Priority>).optional().describe('Filter by priority'),
 	sortBy: z.enum(['dueDate', 'priority', 'title', 'createdAt']).default('dueDate'),
 	sortOrder: z.enum(['asc', 'desc']).default('asc'),
 	limit: z.number().int().min(1).max(100).default(20),
@@ -131,7 +131,7 @@ export const listUpcoming = defineCommand<typeof inputSchema, UpcomingResult>({
 
 		// Offer to filter by high priority
 		if (!input.priority && total > 10) {
-			const highPriority = allUpcoming.filter((t) => t.priority === 'high');
+			const highPriority = allUpcoming.filter((t) => t.priority === 3);
 			if (highPriority.length > 0 && highPriority.length < total) {
 				alternatives.push({
 					data: {

--- a/packages/examples/todo/backends/typescript/src/commands/list.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list.ts
@@ -9,11 +9,12 @@ import { z } from 'zod';
 import { defineCommand, success } from '@afd/server';
 import type { Alternative } from '@afd/core';
 import { store } from '../store/index.js';
-import type { Todo } from '../types.js';
+import type { Todo, Priority } from '../types.js';
+import { PRIORITY_LABELS } from '../types.js';
 
 const inputSchema = z.object({
 	completed: z.boolean().optional(),
-	priority: z.enum(['low', 'medium', 'high']).optional(),
+	priority: (z.number().int().min(0).max(3) as z.ZodType<Priority, z.ZodTypeDef, Priority>).optional(),
 	search: z.string().optional(),
 	dueBefore: z
 		.string()
@@ -77,8 +78,8 @@ export const listTodos = defineCommand<typeof inputSchema, ListResult>({
 		if (input.completed !== undefined) {
 			filters.push(input.completed ? 'completed' : 'pending');
 		}
-		if (input.priority) {
-			filters.push(`${input.priority} priority`);
+		if (input.priority !== undefined) {
+			filters.push(`${PRIORITY_LABELS[input.priority]} priority`);
 		}
 		if (input.search) {
 			filters.push(`matching "${input.search}"`);

--- a/packages/examples/todo/backends/typescript/src/commands/update.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/update.ts
@@ -5,14 +5,15 @@
 import { z } from "zod";
 import { defineCommand, success, failure } from "@afd/server";
 import { store } from "../store/index.js";
-import type { Todo } from "../types.js";
+import type { Todo, Priority } from "../types.js";
+import { PRIORITY_LABELS } from "../types.js";
 
 const inputSchema = z.object({
   id: z.string().min(1, "Todo ID is required"),
   title: z.string().min(1).max(200).optional(),
   description: z.string().max(1000).optional(),
   completed: z.boolean().optional(),
-  priority: z.enum(["low", "medium", "high"]).optional(),
+  priority: (z.number().int().min(0).max(3) as z.ZodType<Priority, z.ZodTypeDef, Priority>).optional(),
   dueDate: z
     .string()
     .datetime({ message: "Due date must be a valid ISO 8601 date-time" })
@@ -75,7 +76,7 @@ export const updateTodo = defineCommand<typeof inputSchema, Todo>({
     const changes: string[] = [];
     if (updates.title) changes.push(`title to "${updates.title}"`);
     if (updates.description !== undefined) changes.push("description");
-    if (updates.priority) changes.push(`priority to ${updates.priority}`);
+    if (updates.priority !== undefined) changes.push(`priority to ${PRIORITY_LABELS[updates.priority]}`);
     if (updates.dueDate !== undefined) {
       if (updates.dueDate === null) {
         changes.push("cleared due date");

--- a/packages/examples/todo/backends/typescript/src/store/file.ts
+++ b/packages/examples/todo/backends/typescript/src/store/file.ts
@@ -108,7 +108,7 @@ export class FileStore {
       id: generateId(),
       title: data.title,
       description: data.description,
-      priority: data.priority ?? "medium",
+      priority: data.priority ?? 2,
       completed: false,
       createdAt: now(),
       updatedAt: now(),
@@ -157,18 +157,13 @@ export class FileStore {
     // Sort
     const sortBy = filter.sortBy ?? "createdAt";
     const sortOrder = filter.sortOrder ?? "desc";
-    const priorityOrder: Record<Priority, number> = {
-      high: 3,
-      medium: 2,
-      low: 1,
-    };
 
     results.sort((a, b) => {
       let comparison = 0;
 
       switch (sortBy) {
         case "priority":
-          comparison = priorityOrder[a.priority] - priorityOrder[b.priority];
+          comparison = a.priority - b.priority;
           break;
         case "title":
           comparison = a.title.localeCompare(b.title);
@@ -307,9 +302,10 @@ export class FileStore {
       pending,
       overdue,
       byPriority: {
-        low: allTodos.filter((t) => t.priority === "low").length,
-        medium: allTodos.filter((t) => t.priority === "medium").length,
-        high: allTodos.filter((t) => t.priority === "high").length,
+        0: allTodos.filter((t) => t.priority === 0).length,
+        1: allTodos.filter((t) => t.priority === 1).length,
+        2: allTodos.filter((t) => t.priority === 2).length,
+        3: allTodos.filter((t) => t.priority === 3).length,
       },
       completionRate: allTodos.length > 0 ? completed / allTodos.length : 0,
     };

--- a/packages/examples/todo/backends/typescript/src/store/memory.ts
+++ b/packages/examples/todo/backends/typescript/src/store/memory.ts
@@ -41,7 +41,7 @@ export class TodoStore {
       id: generateId(),
       title: data.title,
       description: data.description,
-      priority: data.priority ?? "medium",
+      priority: data.priority ?? 2,
       completed: false,
       dueDate: data.dueDate,
       createdAt: now(),
@@ -120,18 +120,13 @@ export class TodoStore {
     // Sort
     const sortBy = filter.sortBy ?? "createdAt";
     const sortOrder = filter.sortOrder ?? "desc";
-    const priorityOrder: Record<Priority, number> = {
-      high: 3,
-      medium: 2,
-      low: 1,
-    };
 
     results.sort((a, b) => {
       let comparison = 0;
 
       switch (sortBy) {
         case "priority":
-          comparison = priorityOrder[a.priority] - priorityOrder[b.priority];
+          comparison = a.priority - b.priority;
           break;
         case "title":
           comparison = a.title.localeCompare(b.title);
@@ -264,9 +259,10 @@ export class TodoStore {
       pending,
       overdue,
       byPriority: {
-        low: todos.filter((t) => t.priority === "low").length,
-        medium: todos.filter((t) => t.priority === "medium").length,
-        high: todos.filter((t) => t.priority === "high").length,
+        0: todos.filter((t) => t.priority === 0).length,
+        1: todos.filter((t) => t.priority === 1).length,
+        2: todos.filter((t) => t.priority === 2).length,
+        3: todos.filter((t) => t.priority === 3).length,
       },
       completionRate: todos.length > 0 ? completed / todos.length : 0,
     };

--- a/packages/examples/todo/backends/typescript/src/types.ts
+++ b/packages/examples/todo/backends/typescript/src/types.ts
@@ -4,8 +4,19 @@
 
 /**
  * Priority levels for todos.
+ * 0 = none, 1 = low, 2 = medium, 3 = high
  */
-export type Priority = 'low' | 'medium' | 'high';
+export type Priority = 0 | 1 | 2 | 3;
+
+/**
+ * Human-readable labels for priority levels.
+ */
+export const PRIORITY_LABELS: Record<Priority, string> = {
+	0: 'none',
+	1: 'low',
+	2: 'medium',
+	3: 'high',
+};
 
 /**
  * Todo item.
@@ -56,11 +67,7 @@ export interface TodoStats {
 	overdue: number;
 
 	/** Breakdown by priority */
-	byPriority: {
-		low: number;
-		medium: number;
-		high: number;
-	};
+	byPriority: Record<Priority, number>;
 
 	/** Completion rate (0-1) */
 	completionRate: number;


### PR DESCRIPTION
## Summary

- Changes `Priority` type from string enum (`'low'|'medium'|'high'`) to numeric (`0|1|2|3`)
- Adds `PRIORITY_LABELS` constant for human-readable priority display
- Updates all commands to use numeric priority with Zod validation (`z.number().int().min(0).max(3)`)
- Updates stores to use direct numeric comparison for sorting (simpler logic)
- Updates `TodoStats.byPriority` to use `Record<Priority, number>`

## Test plan

- [x] All 98 core tests pass
- [x] Priority values correctly validated (0-3 range)
- [x] Human-readable labels used in reasoning output
- [x] Sorting works correctly with numeric priorities

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)