### PR TITLE
feat(todo-react): add markdown editor for todo notes

### DIFF
--- a/packages/examples/todo/frontends/react/package.json
+++ b/packages/examples/todo/frontends/react/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-markdown": "^10.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/packages/examples/todo/frontends/react/src/components/MarkdownEditor.css
+++ b/packages/examples/todo/frontends/react/src/components/MarkdownEditor.css
@@ -1,0 +1,170 @@
+.markdown-editor {
+	display: flex;
+	flex-direction: column;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	overflow: hidden;
+}
+
+.markdown-toolbar {
+	display: flex;
+	gap: 4px;
+	padding: 8px;
+	background: var(--surface);
+	border-bottom: 1px solid var(--border);
+}
+
+.toolbar-btn {
+	padding: 6px 12px;
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	cursor: pointer;
+	border-radius: 4px;
+	font-size: 13px;
+	transition: all 0.2s;
+}
+
+.toolbar-btn:hover:not(:disabled) {
+	background: var(--bg);
+	color: var(--text);
+}
+
+.toolbar-btn.active {
+	background: var(--accent);
+	color: white;
+}
+
+.toolbar-btn:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.markdown-textarea {
+	width: 100%;
+	min-height: 200px;
+	padding: 12px;
+	border: none;
+	background: var(--bg);
+	color: var(--text);
+	font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
+	font-size: 14px;
+	line-height: 1.6;
+	resize: vertical;
+}
+
+.markdown-textarea:focus {
+	outline: none;
+}
+
+.markdown-textarea::placeholder {
+	color: var(--text-muted);
+}
+
+.markdown-preview {
+	min-height: 200px;
+	padding: 12px;
+	background: var(--bg);
+	color: var(--text);
+	line-height: 1.6;
+}
+
+.preview-empty {
+	color: var(--text-muted);
+	font-style: italic;
+}
+
+.markdown-preview h1,
+.markdown-preview h2,
+.markdown-preview h3,
+.markdown-preview h4,
+.markdown-preview h5,
+.markdown-preview h6 {
+	margin-top: 1em;
+	margin-bottom: 0.5em;
+	color: var(--text);
+}
+
+.markdown-preview h1 { font-size: 1.5em; }
+.markdown-preview h2 { font-size: 1.3em; }
+.markdown-preview h3 { font-size: 1.1em; }
+
+.markdown-preview p {
+	margin: 0.5em 0;
+}
+
+.markdown-preview ul,
+.markdown-preview ol {
+	margin: 0.5em 0;
+	padding-left: 1.5em;
+}
+
+.markdown-preview li {
+	margin: 0.25em 0;
+}
+
+.markdown-preview code {
+	background: var(--surface);
+	padding: 2px 6px;
+	border-radius: 4px;
+	font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
+	font-size: 0.9em;
+}
+
+.markdown-preview pre {
+	background: var(--surface);
+	padding: 12px;
+	border-radius: 6px;
+	overflow-x: auto;
+	margin: 0.5em 0;
+}
+
+.markdown-preview pre code {
+	background: none;
+	padding: 0;
+}
+
+.markdown-preview blockquote {
+	border-left: 3px solid var(--accent);
+	margin: 0.5em 0;
+	padding-left: 1em;
+	color: var(--text-muted);
+}
+
+.markdown-preview a {
+	color: var(--accent);
+	text-decoration: none;
+}
+
+.markdown-preview a:hover {
+	text-decoration: underline;
+}
+
+.markdown-preview hr {
+	border: none;
+	border-top: 1px solid var(--border);
+	margin: 1em 0;
+}
+
+.markdown-preview img {
+	max-width: 100%;
+	height: auto;
+	border-radius: 4px;
+}
+
+.markdown-preview table {
+	width: 100%;
+	border-collapse: collapse;
+	margin: 0.5em 0;
+}
+
+.markdown-preview th,
+.markdown-preview td {
+	border: 1px solid var(--border);
+	padding: 8px;
+	text-align: left;
+}
+
+.markdown-preview th {
+	background: var(--surface);
+}

--- a/packages/examples/todo/frontends/react/src/components/MarkdownEditor.tsx
+++ b/packages/examples/todo/frontends/react/src/components/MarkdownEditor.tsx
@@ -1,0 +1,59 @@
+import type React from 'react';
+import { useState } from 'react';
+import Markdown from 'react-markdown';
+import './MarkdownEditor.css';
+
+interface MarkdownEditorProps {
+	value: string;
+	onChange: (value: string) => void;
+	placeholder?: string;
+	readOnly?: boolean;
+}
+
+export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
+	value,
+	onChange,
+	placeholder = 'Write your notes in markdown...',
+	readOnly = false,
+}) => {
+	const [isPreview, setIsPreview] = useState(false);
+
+	return (
+		<div className="markdown-editor">
+			<div className="markdown-toolbar">
+				<button
+					type="button"
+					className={`toolbar-btn ${!isPreview ? 'active' : ''}`}
+					onClick={() => setIsPreview(false)}
+					disabled={readOnly}
+				>
+					Edit
+				</button>
+				<button
+					type="button"
+					className={`toolbar-btn ${isPreview ? 'active' : ''}`}
+					onClick={() => setIsPreview(true)}
+				>
+					Preview
+				</button>
+			</div>
+			{isPreview ? (
+				<div className="markdown-preview">
+					{value ? (
+						<Markdown>{value}</Markdown>
+					) : (
+						<p className="preview-empty">Nothing to preview</p>
+					)}
+				</div>
+			) : (
+				<textarea
+					className="markdown-textarea"
+					value={value}
+					onChange={(e) => onChange(e.target.value)}
+					placeholder={placeholder}
+					disabled={readOnly}
+				/>
+			)}
+		</div>
+	);
+};

--- a/packages/examples/todo/frontends/react/src/components/TodoDetailModal.css
+++ b/packages/examples/todo/frontends/react/src/components/TodoDetailModal.css
@@ -1,0 +1,164 @@
+.detail-modal {
+	background: var(--bg);
+	border-radius: 12px;
+	width: 90%;
+	max-width: 700px;
+	max-height: 90vh;
+	display: flex;
+	flex-direction: column;
+	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.detail-header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 20px 24px;
+	border-bottom: 1px solid var(--border);
+}
+
+.detail-title-input {
+	flex: 1;
+	font-size: 20px;
+	font-weight: 600;
+	border: none;
+	background: transparent;
+	color: var(--text);
+	padding: 8px 0;
+}
+
+.detail-title-input:focus {
+	outline: none;
+}
+
+.detail-title-input::placeholder {
+	color: var(--text-muted);
+}
+
+.close-btn {
+	width: 36px;
+	height: 36px;
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	font-size: 24px;
+	cursor: pointer;
+	border-radius: 6px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: all 0.2s;
+}
+
+.close-btn:hover {
+	background: var(--surface);
+	color: var(--text);
+}
+
+.detail-meta {
+	display: flex;
+	gap: 24px;
+	padding: 16px 24px;
+	background: var(--surface);
+	border-bottom: 1px solid var(--border);
+}
+
+.meta-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 14px;
+}
+
+.meta-item label {
+	color: var(--text-muted);
+}
+
+.priority-select {
+	padding: 4px 8px;
+	border: 1px solid var(--border);
+	border-radius: 4px;
+	background: var(--bg);
+	color: var(--text);
+	font-size: 14px;
+	cursor: pointer;
+}
+
+.priority-select:focus {
+	outline: none;
+	border-color: var(--accent);
+}
+
+.status-badge {
+	padding: 4px 10px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 500;
+}
+
+.status-badge.completed {
+	background: #10b98120;
+	color: #10b981;
+}
+
+.status-badge.pending {
+	background: #f59e0b20;
+	color: #f59e0b;
+}
+
+.detail-body {
+	flex: 1;
+	padding: 20px 24px;
+	overflow-y: auto;
+}
+
+.description-label {
+	display: block;
+	font-size: 14px;
+	font-weight: 500;
+	color: var(--text);
+	margin-bottom: 8px;
+}
+
+.detail-footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 12px;
+	padding: 16px 24px;
+	border-top: 1px solid var(--border);
+}
+
+.btn-secondary {
+	padding: 10px 20px;
+	border: 1px solid var(--border);
+	background: transparent;
+	color: var(--text);
+	border-radius: 6px;
+	font-size: 14px;
+	cursor: pointer;
+	transition: all 0.2s;
+}
+
+.btn-secondary:hover {
+	background: var(--surface);
+}
+
+.btn-primary {
+	padding: 10px 20px;
+	border: none;
+	background: var(--accent);
+	color: white;
+	border-radius: 6px;
+	font-size: 14px;
+	cursor: pointer;
+	transition: all 0.2s;
+}
+
+.btn-primary:hover:not(:disabled) {
+	opacity: 0.9;
+}
+
+.btn-primary:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}

--- a/packages/examples/todo/frontends/react/src/components/TodoDetailModal.tsx
+++ b/packages/examples/todo/frontends/react/src/components/TodoDetailModal.tsx
@@ -1,0 +1,131 @@
+import type React from 'react';
+import { useEffect, useState } from 'react';
+import type { Todo } from '../types';
+import { MarkdownEditor } from './MarkdownEditor';
+import './TodoDetailModal.css';
+
+interface TodoDetailModalProps {
+	todo: Todo | null;
+	onClose: () => void;
+	onSave: (
+		id: string,
+		updates: { title?: string; description?: string; priority?: Todo['priority'] }
+	) => void;
+}
+
+export const TodoDetailModal: React.FC<TodoDetailModalProps> = ({ todo, onClose, onSave }) => {
+	const [title, setTitle] = useState('');
+	const [description, setDescription] = useState('');
+	const [priority, setPriority] = useState<Todo['priority']>('medium');
+	const [hasChanges, setHasChanges] = useState(false);
+
+	useEffect(() => {
+		if (todo) {
+			setTitle(todo.title);
+			setDescription(todo.description || '');
+			setPriority(todo.priority);
+			setHasChanges(false);
+		}
+	}, [todo]);
+
+	if (!todo) return null;
+
+	const handleTitleChange = (newTitle: string) => {
+		setTitle(newTitle);
+		setHasChanges(true);
+	};
+
+	const handleDescriptionChange = (newDescription: string) => {
+		setDescription(newDescription);
+		setHasChanges(true);
+	};
+
+	const handlePriorityChange = (newPriority: Todo['priority']) => {
+		setPriority(newPriority);
+		setHasChanges(true);
+	};
+
+	const handleSave = () => {
+		const updates: { title?: string; description?: string; priority?: Todo['priority'] } = {};
+		if (title !== todo.title) updates.title = title;
+		if (description !== (todo.description || '')) updates.description = description;
+		if (priority !== todo.priority) updates.priority = priority;
+
+		if (Object.keys(updates).length > 0) {
+			onSave(todo.id, updates);
+		}
+		onClose();
+	};
+
+	const handleClose = () => {
+		if (hasChanges) {
+			if (confirm('You have unsaved changes. Are you sure you want to close?')) {
+				onClose();
+			}
+		} else {
+			onClose();
+		}
+	};
+
+	return (
+		<div className="modal-overlay" onClick={handleClose}>
+			<div className="detail-modal" onClick={(e) => e.stopPropagation()}>
+				<div className="detail-header">
+					<input
+						type="text"
+						className="detail-title-input"
+						value={title}
+						onChange={(e) => handleTitleChange(e.target.value)}
+						placeholder="Todo title"
+					/>
+					<button className="close-btn" onClick={handleClose}>
+						&times;
+					</button>
+				</div>
+
+				<div className="detail-meta">
+					<div className="meta-item">
+						<label>Priority:</label>
+						<select
+							value={priority}
+							onChange={(e) => handlePriorityChange(e.target.value as Todo['priority'])}
+							className="priority-select"
+						>
+							<option value="low">Low</option>
+							<option value="medium">Medium</option>
+							<option value="high">High</option>
+						</select>
+					</div>
+					<div className="meta-item">
+						<label>Status:</label>
+						<span className={`status-badge ${todo.completed ? 'completed' : 'pending'}`}>
+							{todo.completed ? 'Completed' : 'Pending'}
+						</span>
+					</div>
+					<div className="meta-item">
+						<label>Created:</label>
+						<span>{new Date(todo.createdAt).toLocaleDateString()}</span>
+					</div>
+				</div>
+
+				<div className="detail-body">
+					<label className="description-label">Notes</label>
+					<MarkdownEditor
+						value={description}
+						onChange={handleDescriptionChange}
+						placeholder="Add notes, links, or any details about this task..."
+					/>
+				</div>
+
+				<div className="detail-footer">
+					<button className="btn-secondary" onClick={handleClose}>
+						Cancel
+					</button>
+					<button className="btn-primary" onClick={handleSave} disabled={!hasChanges}>
+						Save Changes
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+};


### PR DESCRIPTION
## Summary
- Add MarkdownEditor component with edit/preview toggle using react-markdown
- Add TodoDetailModal for viewing and editing todo details with markdown notes
- Add react-markdown dependency (^10.1.0) for rendering markdown content

## Changes
- **MarkdownEditor.tsx**: Reusable markdown editor with toolbar for switching between edit and preview modes
- **MarkdownEditor.css**: Styles for editor including markdown content rendering (headings, code, blockquotes, tables, etc.)
- **TodoDetailModal.tsx**: Modal component for viewing/editing todo title, priority, and markdown description
- **TodoDetailModal.css**: Modal styling with header, meta section, body, and footer
- **package.json**: Added react-markdown dependency

## Test plan
- [ ] Open a todo item to see the detail modal
- [ ] Edit the title and verify changes are tracked
- [ ] Add markdown content in the notes field
- [ ] Toggle between Edit and Preview modes
- [ ] Verify markdown renders correctly (headings, lists, code, links)
- [ ] Save changes and verify they persist
- [ ] Close without saving and verify confirmation dialog

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)