### PR TITLE
feat(todo-py): add suggestion field to error() responses

### DIFF
--- a/packages/examples/todo/backends/python/src/server.py
+++ b/packages/examples/todo/backends/python/src/server.py
@@ -223,7 +223,7 @@ server = create_server(
 @server.command(name="todo.create", description="Create a new todo item", input_schema=CreateTodoInput, mutation=True)
 async def create_todo(input: CreateTodoInput) -> CommandResult[Todo]:
     if input.priority not in ["low", "medium", "high"]:
-        return error(code="INVALID_PRIORITY", message=f"Invalid priority: {input.priority}")
+        return error(code="INVALID_PRIORITY", message=f"Invalid priority: {input.priority}", suggestion="Use 'low', 'medium', or 'high'")
     
     todo = Todo(
         id=str(uuid.uuid4())[:8],
@@ -263,7 +263,7 @@ async def get_todo(input: IdInput) -> CommandResult[Todo]:
     todo_id = input.id
     current_todos = _get_todos()
     if not todo_id or todo_id not in current_todos:
-        return error(code="NOT_FOUND", message=f"Todo '{todo_id}' not found")
+        return error(code="NOT_FOUND", message=f"Todo '{todo_id}' not found", suggestion="Use todo.list to see available todos")
     return success(data=current_todos[todo_id])
 
 
@@ -271,7 +271,7 @@ async def get_todo(input: IdInput) -> CommandResult[Todo]:
 async def update_todo(input: UpdateTodoInput) -> CommandResult[Todo]:
     current_todos = _get_todos()
     if input.id not in current_todos:
-        return error(code="NOT_FOUND", message=f"Todo '{input.id}' not found")
+        return error(code="NOT_FOUND", message=f"Todo '{input.id}' not found", suggestion="Use todo.list to see available todos")
     
     todo = current_todos[input.id]
     if input.title is not None: todo.title = input.title
@@ -284,7 +284,7 @@ async def update_todo(input: UpdateTodoInput) -> CommandResult[Todo]:
         todo.completed = input.completed
     if input.priority is not None:
         if input.priority not in ["low", "medium", "high"]:
-            return error(code="INVALID_PRIORITY", message=f"Invalid priority: {input.priority}")
+            return error(code="INVALID_PRIORITY", message=f"Invalid priority: {input.priority}", suggestion="Use 'low', 'medium', or 'high'")
         todo.priority = input.priority
     
     todo.updatedAt = datetime.utcnow().isoformat() + "Z"
@@ -297,7 +297,7 @@ async def toggle_todo(input: IdInput) -> CommandResult[Todo]:
     todo_id = input.id
     current_todos = _get_todos()
     if not todo_id or todo_id not in current_todos:
-        return error(code="NOT_FOUND", message=f"Todo '{todo_id}' not found")
+        return error(code="NOT_FOUND", message=f"Todo '{todo_id}' not found", suggestion="Use todo.list to see available todos")
     
     todo = current_todos[todo_id]
     todo.completed = not todo.completed
@@ -316,7 +316,7 @@ async def delete_todo(input: IdInput) -> CommandResult[Dict[str, Any]]:
     todo_id = input.id
     current_todos = _get_todos()
     if not todo_id or todo_id not in current_todos:
-        return error(code="NOT_FOUND", message=f"Todo '{todo_id}' not found")
+        return error(code="NOT_FOUND", message=f"Todo '{todo_id}' not found", suggestion="Use todo.list to see available todos")
     
     deleted = current_todos[todo_id]
     _delete_todo(todo_id)

--- a/python/tests/test_result.py
+++ b/python/tests/test_result.py
@@ -155,6 +155,22 @@ class TestErrorHelper:
         )
         assert result.error.details == {"field": "email", "constraint": "format"}
 
+    def test_error_with_all_fields(self):
+        """Test error() helper with all fields (AFD compliance)."""
+        result = error(
+            "NOT_FOUND",
+            "Todo not found",
+            suggestion="Use todo.list to see available todos",
+            retryable=False,
+            details={"resource": "todo", "id": "abc123"},
+        )
+        assert result.success is False
+        assert result.error.code == "NOT_FOUND"
+        assert result.error.message == "Todo not found"
+        assert result.error.suggestion == "Use todo.list to see available todos"
+        assert result.error.retryable is False
+        assert result.error.details == {"resource": "todo", "id": "abc123"}
+
 
 class TestIsSuccess:
     """Tests for is_success() type guard."""


### PR DESCRIPTION
## Summary
- Add `suggestion` parameter to all `error()` calls in the Python todo example
- Error responses now provide actionable recovery guidance for agents
- Add comprehensive test for `error()` helper with all fields (AFD compliance)

## Changes
- **server.py**: Update 6 error responses with suggestion field
  - `INVALID_PRIORITY`: "Use 'low', 'medium', or 'high'"
  - `NOT_FOUND`: "Use todo.list to see available todos"
- **test_result.py**: Add `test_error_with_all_fields` test

## Test plan
- [x] Python unit tests pass (23 tests including new test)
- [x] Verify suggestion field appears in error responses
- [x] Verify test covers all error() parameters

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)