### PR TITLE
feat(todo-ts): add notes and note folders backend support

### DIFF
--- a/packages/examples/todo/backends/typescript/src/commands/clear.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/clear.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from "zod";
-import { defineCommand, success } from "@afd/server";
+import { defineCommand, success } from "@lushly-dev/afd-server";
 import { store } from "../store/index.js";
 
 const inputSchema = z.object({

--- a/packages/examples/todo/backends/typescript/src/commands/complete.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/complete.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success, failure } from '@afd/server';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { Todo } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/create-batch.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/create-batch.ts
@@ -6,8 +6,8 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success } from '@afd/server';
-import type { CommandError } from '@afd/core';
+import { defineCommand, success } from '@lushly-dev/afd-server';
+import type { CommandError } from '@lushly-dev/afd-core';
 import { store } from '../store/index.js';
 import type { Todo, Priority } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/create.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/create.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success } from '@afd/server';
+import { defineCommand, success } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { Todo, Priority } from '../types.js';
 import { PRIORITY_LABELS } from '../types.js';

--- a/packages/examples/todo/backends/typescript/src/commands/delete-batch.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/delete-batch.ts
@@ -5,8 +5,8 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success } from '@afd/server';
-import type { CommandError } from '@afd/core';
+import { defineCommand, success } from '@lushly-dev/afd-server';
+import type { CommandError } from '@lushly-dev/afd-core';
 import { store } from '../store/index.js';
 
 const inputSchema = z.object({

--- a/packages/examples/todo/backends/typescript/src/commands/delete.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/delete.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success, failure } from '@afd/server';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 
 const inputSchema = z.object({

--- a/packages/examples/todo/backends/typescript/src/commands/get.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/get.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success, failure } from '@afd/server';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { Todo } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/index.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/index.ts
@@ -36,6 +36,21 @@ export { addSubtask } from './subtask-add.js';
 export { listSubtasks, type SubtaskListResult } from './subtask-list.js';
 export { moveSubtask } from './subtask-move.js';
 
+
+// Note operations
+export { createNote } from './note-create.js';
+export { getNote } from './note-get.js';
+export { listNotes, type NoteListResult } from './note-list.js';
+export { updateNote } from './note-update.js';
+export { deleteNote, type NoteDeleteResult } from './note-delete.js';
+
+// Note folder operations
+export { createNoteFolder } from './notefolder-create.js';
+export { getNoteFolder } from './notefolder-get.js';
+export { listNoteFolders, type NoteFolderListResult } from './notefolder-list.js';
+export { updateNoteFolder } from './notefolder-update.js';
+export { deleteNoteFolder, type NoteFolderDeleteResult } from './notefolder-delete.js';
+
 // Re-export as array for convenience
 import { createTodo } from './create.js';
 import { listTodos } from './list.js';
@@ -64,7 +79,19 @@ import { searchTodos } from './search.js';
 import { addSubtask } from './subtask-add.js';
 import { listSubtasks } from './subtask-list.js';
 import { moveSubtask } from './subtask-move.js';
-import type { ZodCommandDefinition } from '@afd/server';
+// Note operations
+import { createNote } from './note-create.js';
+import { getNote } from './note-get.js';
+import { listNotes } from './note-list.js';
+import { updateNote } from './note-update.js';
+import { deleteNote } from './note-delete.js';
+// Note folder operations
+import { createNoteFolder } from './notefolder-create.js';
+import { getNoteFolder } from './notefolder-get.js';
+import { listNoteFolders } from './notefolder-list.js';
+import { updateNoteFolder } from './notefolder-update.js';
+import { deleteNoteFolder } from './notefolder-delete.js';
+import type { ZodCommandDefinition } from '@lushly-dev/afd-server';
 
 /**
  * All todo commands as an array.

--- a/packages/examples/todo/backends/typescript/src/commands/list-create.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-create.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success } from '@afd/server';
+import { defineCommand, success } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { List } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/list-delete.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-delete.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success, failure } from '@afd/server';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 
 const inputSchema = z.object({

--- a/packages/examples/todo/backends/typescript/src/commands/list-list.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-list.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success } from '@afd/server';
+import { defineCommand, success } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { List } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/list-today.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-today.ts
@@ -6,8 +6,8 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success } from '@afd/server';
-import type { Alternative } from '@afd/core';
+import { defineCommand, success } from '@lushly-dev/afd-server';
+import type { Alternative } from '@lushly-dev/afd-core';
 import { store } from '../store/index.js';
 import type { Todo } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/list-upcoming.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-upcoming.ts
@@ -6,8 +6,8 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success } from '@afd/server';
-import type { Alternative } from '@afd/core';
+import { defineCommand, success } from '@lushly-dev/afd-server';
+import type { Alternative } from '@lushly-dev/afd-core';
 import { store } from '../store/index.js';
 import type { Todo, Priority } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/list-update.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list-update.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success, failure } from '@afd/server';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { List } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/list.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/list.ts
@@ -6,8 +6,8 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success } from '@afd/server';
-import type { Alternative } from '@afd/core';
+import { defineCommand, success } from '@lushly-dev/afd-server';
+import type { Alternative } from '@lushly-dev/afd-core';
 import { store } from '../store/index.js';
 import type { Todo, Priority } from '../types.js';
 import { PRIORITY_LABELS } from '../types.js';

--- a/packages/examples/todo/backends/typescript/src/commands/note-create.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/note-create.ts
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview note-create command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success } from '@lushly-dev/afd-server';
+import { store } from '../store/index.js';
+import type { Note } from '../types.js';
+
+const inputSchema = z.object({
+	title: z.string().min(1, 'Title is required').max(200, 'Title too long'),
+	content: z.string().max(50000).default(''),
+	folderId: z.string().optional(),
+});
+
+export const createNote = defineCommand<typeof inputSchema, Note>({
+	name: 'note-create',
+	description: 'Create a new note',
+	category: 'note',
+	tags: ['note', 'create', 'write', 'single'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['VALIDATION_ERROR', 'FOLDER_NOT_FOUND'],
+
+	async handler(input) {
+		if (input.folderId) {
+			const folder = store.getNoteFolder(input.folderId);
+			if (!folder) {
+				return { success: false, error: { code: 'FOLDER_NOT_FOUND', message: 'Folder not found: ' + input.folderId, suggestion: 'Create the folder first or omit folderId' } };
+			}
+		}
+		const note = store.createNote({ title: input.title, content: input.content, folderId: input.folderId });
+		return success(note, { reasoning: 'Created note "' + note.title + '"', confidence: 1.0 });
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/note-delete.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/note-delete.ts
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview note-delete command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
+import { store } from '../store/index.js';
+
+export interface NoteDeleteResult {
+	id: string;
+	deleted: boolean;
+}
+
+const inputSchema = z.object({
+	id: z.string().min(1, 'Note ID is required'),
+});
+
+export const deleteNote = defineCommand<typeof inputSchema, NoteDeleteResult>({
+	name: 'note-delete',
+	description: 'Delete a note',
+	category: 'note',
+	tags: ['note', 'delete', 'write', 'single'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['NOT_FOUND'],
+
+	async handler(input) {
+		const note = store.getNote(input.id);
+		if (!note) {
+			return failure({ code: 'NOT_FOUND', message: 'Note not found: ' + input.id, suggestion: 'Check the note ID or list all notes' });
+		}
+		const deleted = store.deleteNote(input.id);
+		return success({ id: input.id, deleted }, { reasoning: 'Deleted note "' + note.title + '"', confidence: 1.0 });
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/note-get.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/note-get.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview note-get command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
+import { store } from '../store/index.js';
+import type { Note } from '../types.js';
+
+const inputSchema = z.object({
+	id: z.string().min(1, 'Note ID is required'),
+});
+
+export const getNote = defineCommand<typeof inputSchema, Note>({
+	name: 'note-get',
+	description: 'Get a note by ID',
+	category: 'note',
+	tags: ['note', 'get', 'read', 'single'],
+	mutation: false,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['NOT_FOUND'],
+
+	async handler(input) {
+		const note = store.getNote(input.id);
+		if (!note) {
+			return failure({ code: 'NOT_FOUND', message: 'Note not found: ' + input.id, suggestion: 'Check the note ID or list all notes' });
+		}
+		return success(note, { reasoning: 'Retrieved note "' + note.title + '"', confidence: 1.0 });
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/note-list.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/note-list.ts
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview note-list command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success } from '@lushly-dev/afd-server';
+import { store } from '../store/index.js';
+import type { Note } from '../types.js';
+
+export interface NoteListResult {
+	notes: Note[];
+	total: number;
+}
+
+const inputSchema = z.object({
+	search: z.string().optional(),
+	folderId: z.string().nullable().optional(),
+	sortBy: z.enum(['createdAt', 'updatedAt', 'title']).default('createdAt'),
+	sortOrder: z.enum(['asc', 'desc']).default('desc'),
+	limit: z.number().int().min(1).max(100).default(50),
+	offset: z.number().int().min(0).default(0),
+});
+
+export const listNotes = defineCommand<typeof inputSchema, NoteListResult>({
+	name: 'note-list',
+	description: 'List notes with optional filtering',
+	category: 'note',
+	tags: ['note', 'list', 'read', 'multiple'],
+	mutation: false,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: [],
+
+	async handler(input) {
+		const notes = store.listNotes({
+			search: input.search,
+			folderId: input.folderId,
+			sortBy: input.sortBy,
+			sortOrder: input.sortOrder,
+			limit: input.limit,
+			offset: input.offset,
+		});
+		const total = store.countNotes();
+		let reasoning = 'Found ' + notes.length + ' notes';
+		if (input.search) reasoning += ' matching "' + input.search + '"';
+		return success({ notes, total }, { reasoning, confidence: 1.0 });
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/note-update.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/note-update.ts
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview note-update command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
+import { store } from '../store/index.js';
+import type { Note } from '../types.js';
+
+const inputSchema = z.object({
+	id: z.string().min(1, 'Note ID is required'),
+	title: z.string().min(1).max(200).optional(),
+	content: z.string().max(50000).optional(),
+	folderId: z.string().nullable().optional(),
+});
+
+export const updateNote = defineCommand<typeof inputSchema, Note>({
+	name: 'note-update',
+	description: 'Update an existing note',
+	category: 'note',
+	tags: ['note', 'update', 'write', 'single'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['NOT_FOUND', 'FOLDER_NOT_FOUND'],
+
+	async handler(input) {
+		const existing = store.getNote(input.id);
+		if (!existing) {
+			return failure({ code: 'NOT_FOUND', message: 'Note not found: ' + input.id, suggestion: 'Check the note ID or list all notes' });
+		}
+		if (input.folderId) {
+			const folder = store.getNoteFolder(input.folderId);
+			if (!folder) {
+				return failure({ code: 'FOLDER_NOT_FOUND', message: 'Folder not found: ' + input.folderId, suggestion: 'Create the folder first' });
+			}
+		}
+		const note = store.updateNote(input.id, { title: input.title, content: input.content, folderId: input.folderId })!;
+		return success(note, { reasoning: 'Updated note "' + note.title + '"', confidence: 1.0 });
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/notefolder-create.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/notefolder-create.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview notefolder-create command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success } from '@lushly-dev/afd-server';
+import { store } from '../store/index.js';
+import type { NoteFolder } from '../types.js';
+
+const inputSchema = z.object({
+	name: z.string().min(1, 'Name is required').max(100, 'Name too long'),
+	description: z.string().max(500).optional(),
+});
+
+export const createNoteFolder = defineCommand<typeof inputSchema, NoteFolder>({
+	name: 'notefolder-create',
+	description: 'Create a new note folder',
+	category: 'note',
+	tags: ['note', 'folder', 'create', 'write'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['VALIDATION_ERROR'],
+
+	async handler(input) {
+		const folder = store.createNoteFolder({ name: input.name, description: input.description });
+		return success(folder, { reasoning: 'Created folder "' + folder.name + '"', confidence: 1.0 });
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/notefolder-delete.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/notefolder-delete.ts
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview notefolder-delete command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
+import { store } from '../store/index.js';
+
+export interface NoteFolderDeleteResult {
+	id: string;
+	deleted: boolean;
+	notesOrphaned: number;
+}
+
+const inputSchema = z.object({
+	id: z.string().min(1, 'Folder ID is required'),
+});
+
+export const deleteNoteFolder = defineCommand<typeof inputSchema, NoteFolderDeleteResult>({
+	name: 'notefolder-delete',
+	description: 'Delete a note folder (notes in the folder are moved to root)',
+	category: 'note',
+	tags: ['note', 'folder', 'delete', 'write'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['NOT_FOUND'],
+
+	async handler(input) {
+		const folder = store.getNoteFolder(input.id);
+		if (!folder) {
+			return failure({ code: 'NOT_FOUND', message: 'Folder not found: ' + input.id, suggestion: 'Check the folder ID or list all folders' });
+		}
+		const notesInFolder = store.getNotesInFolder(input.id);
+		for (const note of notesInFolder) {
+			store.updateNote(note.id, { folderId: null });
+		}
+		const deleted = store.deleteNoteFolder(input.id);
+		return success({ id: input.id, deleted, notesOrphaned: notesInFolder.length }, { reasoning: 'Deleted folder "' + folder.name + '", moved ' + notesInFolder.length + ' notes to root', confidence: 1.0 });
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/notefolder-get.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/notefolder-get.ts
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview notefolder-get command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
+import { store } from '../store/index.js';
+import type { NoteFolder, Note } from '../types.js';
+
+interface NoteFolderWithNotes extends NoteFolder {
+	notes: Note[];
+}
+
+const inputSchema = z.object({
+	id: z.string().min(1, 'Folder ID is required'),
+	includeNotes: z.boolean().default(false),
+});
+
+export const getNoteFolder = defineCommand<typeof inputSchema, NoteFolderWithNotes>({
+	name: 'notefolder-get',
+	description: 'Get a note folder by ID',
+	category: 'note',
+	tags: ['note', 'folder', 'get', 'read'],
+	mutation: false,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['NOT_FOUND'],
+
+	async handler(input) {
+		const folder = store.getNoteFolder(input.id);
+		if (!folder) {
+			return failure({ code: 'NOT_FOUND', message: 'Folder not found: ' + input.id, suggestion: 'Check the folder ID or list all folders' });
+		}
+		const notes = input.includeNotes ? store.getNotesInFolder(input.id) : [];
+		return success({ ...folder, notes }, { reasoning: 'Retrieved folder "' + folder.name + '"' + (input.includeNotes ? ' with ' + notes.length + ' notes' : ''), confidence: 1.0 });
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/notefolder-list.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/notefolder-list.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview notefolder-list command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success } from '@lushly-dev/afd-server';
+import { store } from '../store/index.js';
+import type { NoteFolder } from '../types.js';
+
+export interface NoteFolderListResult {
+	folders: NoteFolder[];
+	total: number;
+}
+
+const inputSchema = z.object({
+	search: z.string().optional(),
+	sortBy: z.enum(['createdAt', 'updatedAt', 'name']).default('createdAt'),
+	sortOrder: z.enum(['asc', 'desc']).default('desc'),
+	limit: z.number().int().min(1).max(100).default(50),
+	offset: z.number().int().min(0).default(0),
+});
+
+export const listNoteFolders = defineCommand<typeof inputSchema, NoteFolderListResult>({
+	name: 'notefolder-list',
+	description: 'List note folders with optional filtering',
+	category: 'note',
+	tags: ['note', 'folder', 'list', 'read'],
+	mutation: false,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: [],
+
+	async handler(input) {
+		const folders = store.listNoteFolders({
+			search: input.search,
+			sortBy: input.sortBy,
+			sortOrder: input.sortOrder,
+			limit: input.limit,
+			offset: input.offset,
+		});
+		const total = store.countNoteFolders();
+		let reasoning = 'Found ' + folders.length + ' folders';
+		if (input.search) reasoning += ' matching "' + input.search + '"';
+		return success({ folders, total }, { reasoning, confidence: 1.0 });
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/notefolder-update.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/notefolder-update.ts
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview notefolder-update command
+ */
+
+import { z } from 'zod';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
+import { store } from '../store/index.js';
+import type { NoteFolder } from '../types.js';
+
+const inputSchema = z.object({
+	id: z.string().min(1, 'Folder ID is required'),
+	name: z.string().min(1).max(100).optional(),
+	description: z.string().max(500).optional(),
+});
+
+export const updateNoteFolder = defineCommand<typeof inputSchema, NoteFolder>({
+	name: 'notefolder-update',
+	description: 'Update an existing note folder',
+	category: 'note',
+	tags: ['note', 'folder', 'update', 'write'],
+	mutation: true,
+	version: '1.0.0',
+	input: inputSchema,
+	errors: ['NOT_FOUND'],
+
+	async handler(input) {
+		const existing = store.getNoteFolder(input.id);
+		if (!existing) {
+			return failure({ code: 'NOT_FOUND', message: 'Folder not found: ' + input.id, suggestion: 'Check the folder ID or list all folders' });
+		}
+		const folder = store.updateNoteFolder(input.id, { name: input.name, description: input.description })!;
+		return success(folder, { reasoning: 'Updated folder "' + folder.name + '"', confidence: 1.0 });
+	},
+});

--- a/packages/examples/todo/backends/typescript/src/commands/stats.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/stats.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success } from '@afd/server';
+import { defineCommand, success } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { TodoStats } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/subtask-add.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/subtask-add.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success, failure } from '@afd/server';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { Todo, Priority } from '../types.js';
 import { PRIORITY_LABELS } from '../types.js';

--- a/packages/examples/todo/backends/typescript/src/commands/subtask-list.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/subtask-list.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success, failure } from '@afd/server';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { Todo } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/subtask-move.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/subtask-move.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success, failure } from '@afd/server';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { Todo } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/toggle-batch.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/toggle-batch.ts
@@ -6,8 +6,8 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success } from '@afd/server';
-import type { CommandError } from '@afd/core';
+import { defineCommand, success } from '@lushly-dev/afd-server';
+import type { CommandError } from '@lushly-dev/afd-core';
 import { store } from '../store/index.js';
 import type { Todo } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/toggle.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/toggle.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success, failure } from '@afd/server';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { Todo } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/uncomplete.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/uncomplete.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { defineCommand, success, failure } from '@afd/server';
+import { defineCommand, success, failure } from '@lushly-dev/afd-server';
 import { store } from '../store/index.js';
 import type { Todo } from '../types.js';
 

--- a/packages/examples/todo/backends/typescript/src/commands/update.ts
+++ b/packages/examples/todo/backends/typescript/src/commands/update.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from "zod";
-import { defineCommand, success, failure } from "@afd/server";
+import { defineCommand, success, failure } from "@lushly-dev/afd-server";
 import { store } from "../store/index.js";
 import type { Todo, Priority } from "../types.js";
 import { PRIORITY_LABELS } from "../types.js";

--- a/packages/examples/todo/backends/typescript/src/store/file.ts
+++ b/packages/examples/todo/backends/typescript/src/store/file.ts
@@ -11,7 +11,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Todo, TodoFilter, TodoStats, Priority, List, ListFilter } from "../types.js";
+import type { Todo, TodoFilter, TodoStats, Priority, List, ListFilter, Note, NoteFolder, NoteFilter, NoteFolderFilter } from "../types.js";
 
 // Get the directory of this file for consistent path resolution
 const __filename = fileURLToPath(import.meta.url);
@@ -37,6 +37,8 @@ function now(): string {
 export class FileStore {
   private filePath: string;
   private listsFilePath: string;
+  private notesFilePath: string;
+  private noteFoldersFilePath: string;
 
   constructor(filePath?: string) {
     // Default path: packages/examples/todo/data/todos.json
@@ -45,6 +47,12 @@ export class FileStore {
     this.listsFilePath = filePath
       ? filePath.replace(/\.json$/, '-lists.json')
       : resolve(__dirname, "..", "..", "..", "..", "data", "lists.json");
+    this.notesFilePath = filePath
+      ? filePath.replace(/\.json$/, '-notes.json')
+      : resolve(__dirname, "..", "..", "..", "..", "data", "notes.json");
+    this.noteFoldersFilePath = filePath
+      ? filePath.replace(/\.json$/, '-notefolders.json')
+      : resolve(__dirname, "..", "..", "..", "..", "data", "notefolders.json");
 
     // Ensure the directory exists
     const dir = dirname(this.filePath);
@@ -58,6 +66,12 @@ export class FileStore {
     }
     if (!existsSync(this.listsFilePath)) {
       this.saveLists(new Map());
+    }
+    if (!existsSync(this.notesFilePath)) {
+      this.saveNotes(new Map());
+    }
+    if (!existsSync(this.noteFoldersFilePath)) {
+      this.saveNoteFolders(new Map());
     }
   }
 
@@ -360,11 +374,13 @@ export class FileStore {
   }
 
   /**
-   * Clear all todos and lists (for testing).
+   * Clear all todos, lists, notes, and note folders (for testing).
    */
   clear(): void {
     this.saveTodos(new Map());
     this.saveLists(new Map());
+    this.saveNotes(new Map());
+    this.saveNoteFolders(new Map());
   }
 
   /**
@@ -621,4 +637,179 @@ export class FileStore {
   clearLists(): void {
     this.saveLists(new Map());
   }
+
+  // ==================== Note Methods ====================
+
+  private loadNotes(): Map<string, Note> {
+    try {
+      const data = readFileSync(this.notesFilePath, "utf-8");
+      const parsed = JSON.parse(data);
+      if (Array.isArray(parsed)) {
+        const map = new Map<string, Note>();
+        for (const note of parsed) { map.set(note.id, note); }
+        return map;
+      }
+      return new Map(Object.entries(parsed));
+    } catch { return new Map(); }
+  }
+
+  private saveNotes(notes: Map<string, Note>): void {
+    const data = Array.from(notes.values());
+    writeFileSync(this.notesFilePath, JSON.stringify(data, null, 2), "utf-8");
+  }
+
+  createNote(data: { title: string; content: string; folderId?: string }): Note {
+    const notes = this.loadNotes();
+    const note: Note = {
+      id: generateId('note'),
+      title: data.title,
+      content: data.content,
+      folderId: data.folderId,
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    notes.set(note.id, note);
+    this.saveNotes(notes);
+    return note;
+  }
+
+  getNote(id: string): Note | undefined {
+    return this.loadNotes().get(id);
+  }
+
+  listNotes(filter: NoteFilter = {}): Note[] {
+    const notes = this.loadNotes();
+    let results = Array.from(notes.values());
+    if (filter.search) {
+      const search = filter.search.toLowerCase();
+      results = results.filter((n) => n.title.toLowerCase().includes(search) || n.content.toLowerCase().includes(search));
+    }
+    if (filter.folderId !== undefined) {
+      if (filter.folderId === null) { results = results.filter((n) => !n.folderId); }
+      else { results = results.filter((n) => n.folderId === filter.folderId); }
+    }
+    const sortBy = filter.sortBy ?? 'createdAt';
+    const sortOrder = filter.sortOrder ?? 'desc';
+    results.sort((a, b) => {
+      let cmp = 0;
+      switch (sortBy) {
+        case 'title': cmp = a.title.localeCompare(b.title); break;
+        case 'updatedAt': cmp = a.updatedAt.localeCompare(b.updatedAt); break;
+        default: cmp = a.createdAt.localeCompare(b.createdAt);
+      }
+      return sortOrder === 'asc' ? cmp : -cmp;
+    });
+    const offset = filter.offset ?? 0;
+    const limit = filter.limit ?? 100;
+    return results.slice(offset, offset + limit);
+  }
+
+  updateNote(id: string, data: Partial<Pick<Note, 'title' | 'content'>> & { folderId?: string | null }): Note | undefined {
+    const notes = this.loadNotes();
+    const note = notes.get(id);
+    if (!note) return undefined;
+    const filtered: Partial<Pick<Note, 'title' | 'content' | 'folderId'>> = {};
+    if (data.title !== undefined) filtered.title = data.title;
+    if (data.content !== undefined) filtered.content = data.content;
+    if (data.folderId !== undefined) filtered.folderId = data.folderId === null ? undefined : data.folderId;
+    const updated: Note = { ...note, ...filtered, updatedAt: now() };
+    notes.set(id, updated);
+    this.saveNotes(notes);
+    return updated;
+  }
+
+  deleteNote(id: string): boolean {
+    const notes = this.loadNotes();
+    const existed = notes.delete(id);
+    if (existed) this.saveNotes(notes);
+    return existed;
+  }
+
+  countNotes(): number { return this.loadNotes().size; }
+  clearNotes(): void { this.saveNotes(new Map()); }
+  getNotesInFolder(folderId: string): Note[] {
+    return Array.from(this.loadNotes().values()).filter((n) => n.folderId === folderId);
+  }
+
+  // ==================== NoteFolder Methods ====================
+
+  private loadNoteFolders(): Map<string, NoteFolder> {
+    try {
+      const data = readFileSync(this.noteFoldersFilePath, "utf-8");
+      const parsed = JSON.parse(data);
+      if (Array.isArray(parsed)) {
+        const map = new Map<string, NoteFolder>();
+        for (const folder of parsed) { map.set(folder.id, folder); }
+        return map;
+      }
+      return new Map(Object.entries(parsed));
+    } catch { return new Map(); }
+  }
+
+  private saveNoteFolders(folders: Map<string, NoteFolder>): void {
+    const data = Array.from(folders.values());
+    writeFileSync(this.noteFoldersFilePath, JSON.stringify(data, null, 2), "utf-8");
+  }
+
+  createNoteFolder(data: { name: string; description?: string }): NoteFolder {
+    const folders = this.loadNoteFolders();
+    const folder: NoteFolder = {
+      id: generateId('folder'),
+      name: data.name,
+      description: data.description,
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    folders.set(folder.id, folder);
+    this.saveNoteFolders(folders);
+    return folder;
+  }
+
+  getNoteFolder(id: string): NoteFolder | undefined { return this.loadNoteFolders().get(id); }
+
+  listNoteFolders(filter: NoteFolderFilter = {}): NoteFolder[] {
+    const folders = this.loadNoteFolders();
+    let results = Array.from(folders.values());
+    if (filter.search) {
+      const search = filter.search.toLowerCase();
+      results = results.filter((f) => f.name.toLowerCase().includes(search) || f.description?.toLowerCase().includes(search));
+    }
+    const sortBy = filter.sortBy ?? 'createdAt';
+    const sortOrder = filter.sortOrder ?? 'desc';
+    results.sort((a, b) => {
+      let cmp = 0;
+      switch (sortBy) {
+        case 'name': cmp = a.name.localeCompare(b.name); break;
+        case 'updatedAt': cmp = a.updatedAt.localeCompare(b.updatedAt); break;
+        default: cmp = a.createdAt.localeCompare(b.createdAt);
+      }
+      return sortOrder === 'asc' ? cmp : -cmp;
+    });
+    const offset = filter.offset ?? 0;
+    const limit = filter.limit ?? 100;
+    return results.slice(offset, offset + limit);
+  }
+
+  updateNoteFolder(id: string, data: Partial<Pick<NoteFolder, 'name' | 'description'>>): NoteFolder | undefined {
+    const folders = this.loadNoteFolders();
+    const folder = folders.get(id);
+    if (!folder) return undefined;
+    const filtered: Partial<Pick<NoteFolder, 'name' | 'description'>> = {};
+    if (data.name !== undefined) filtered.name = data.name;
+    if (data.description !== undefined) filtered.description = data.description;
+    const updated: NoteFolder = { ...folder, ...filtered, updatedAt: now() };
+    folders.set(id, updated);
+    this.saveNoteFolders(folders);
+    return updated;
+  }
+
+  deleteNoteFolder(id: string): boolean {
+    const folders = this.loadNoteFolders();
+    const existed = folders.delete(id);
+    if (existed) this.saveNoteFolders(folders);
+    return existed;
+  }
+
+  countNoteFolders(): number { return this.loadNoteFolders().size; }
+  clearNoteFolders(): void { this.saveNoteFolders(new Map()); }
 }

--- a/packages/examples/todo/backends/typescript/src/store/memory.ts
+++ b/packages/examples/todo/backends/typescript/src/store/memory.ts
@@ -26,9 +26,9 @@ function now(): string {
  */
 export class TodoStore {
   private todos: Map<string, Todo> = new Map();
+  private lists: Map<string, List> = new Map();
   private notes: Map<string, Note> = new Map();
   private noteFolders: Map<string, NoteFolder> = new Map();
-  private lists: Map<string, List> = new Map();
 
   /**
    * Create a new todo.
@@ -288,9 +288,14 @@ export class TodoStore {
   }
 
   /**
-   * Clear all todos and lists (for testing).
+   * Clear all todos, lists, notes, and note folders (for testing).
    */
-  clear(): void { this.todos.clear(); this.lists.clear(); this.notes.clear(); this.noteFolders.clear(); }
+  clear(): void {
+    this.todos.clear();
+    this.lists.clear();
+    this.notes.clear();
+    this.noteFolders.clear();
+  }
 
   /**
    * Get count of todos.
@@ -493,7 +498,10 @@ export class TodoStore {
   /**
    * Clear all lists (for testing).
    */
-  clearLists(): void { this.lists.clear(); }
+  clearLists(): void {
+    this.lists.clear();
+  }
+
   // ==================== Note Methods ====================
 
   createNote(data: { title: string; content: string; folderId?: string }): Note {
@@ -554,9 +562,18 @@ export class TodoStore {
     return updated;
   }
 
-  deleteNote(id: string): boolean { return this.notes.delete(id); }
-  countNotes(): number { return this.notes.size; }
-  clearNotes(): void { this.notes.clear(); }
+  deleteNote(id: string): boolean {
+    return this.notes.delete(id);
+  }
+
+  countNotes(): number {
+    return this.notes.size;
+  }
+
+  clearNotes(): void {
+    this.notes.clear();
+  }
+
   getNotesInFolder(folderId: string): Note[] {
     return Array.from(this.notes.values()).filter((n) => n.folderId === folderId);
   }
@@ -575,7 +592,9 @@ export class TodoStore {
     return folder;
   }
 
-  getNoteFolder(id: string): NoteFolder | undefined { return this.noteFolders.get(id); }
+  getNoteFolder(id: string): NoteFolder | undefined {
+    return this.noteFolders.get(id);
+  }
 
   listNoteFolders(filter: NoteFolderFilter = {}): NoteFolder[] {
     let results = Array.from(this.noteFolders.values());
@@ -610,9 +629,17 @@ export class TodoStore {
     return updated;
   }
 
-  deleteNoteFolder(id: string): boolean { return this.noteFolders.delete(id); }
-  countNoteFolders(): number { return this.noteFolders.size; }
-  clearNoteFolders(): void { this.noteFolders.clear(); }
+  deleteNoteFolder(id: string): boolean {
+    return this.noteFolders.delete(id);
+  }
+
+  countNoteFolders(): number {
+    return this.noteFolders.size;
+  }
+
+  clearNoteFolders(): void {
+    this.noteFolders.clear();
+  }
 }
 
 /**

--- a/packages/examples/todo/backends/typescript/src/types.ts
+++ b/packages/examples/todo/backends/typescript/src/types.ts
@@ -156,3 +156,126 @@ export interface ListFilter {
 	/** Offset for pagination */
 	offset?: number;
 }
+
+/**
+ * A note item.
+ */
+export interface Note {
+	/** Unique identifier */
+	id: string;
+
+	/** Note title */
+	title: string;
+
+	/** Note content (markdown supported) */
+	content: string;
+
+	/** Parent folder ID (undefined for root-level notes) */
+	folderId?: string;
+
+	/** Creation timestamp */
+	createdAt: string;
+
+	/** Last update timestamp */
+	updatedAt: string;
+}
+
+/**
+ * A folder that groups notes together.
+ */
+export interface NoteFolder {
+	/** Unique identifier */
+	id: string;
+
+	/** Folder name */
+	name: string;
+
+	/** Optional description */
+	description?: string;
+
+	/** Creation timestamp */
+	createdAt: string;
+
+	/** Last update timestamp */
+	updatedAt: string;
+}
+
+/**
+ * Filter options for listing notes.
+ */
+export interface NoteFilter {
+	/** Search in title/content */
+	search?: string;
+
+	/** Filter by folder ID (null = root-level only, string = notes in that folder) */
+	folderId?: string | null;
+
+	/** Sort field */
+	sortBy?: 'createdAt' | 'updatedAt' | 'title';
+
+	/** Sort direction */
+	sortOrder?: 'asc' | 'desc';
+
+	/** Maximum results */
+	limit?: number;
+
+	/** Offset for pagination */
+	offset?: number;
+}
+
+/**
+ * Filter options for listing note folders.
+ */
+export interface NoteFolderFilter {
+	/** Search in name/description */
+	search?: string;
+
+	/** Sort field */
+	sortBy?: 'createdAt' | 'updatedAt' | 'name';
+
+	/** Sort direction */
+	sortOrder?: 'asc' | 'desc';
+
+	/** Maximum results */
+	limit?: number;
+
+	/** Offset for pagination */
+	offset?: number;
+}
+
+/**
+ * A note item.
+ */
+export interface Note {
+	id: string;
+	title: string;
+	content: string;
+	folderId?: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface NoteFolder {
+	id: string;
+	name: string;
+	description?: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface NoteFilter {
+	search?: string;
+	folderId?: string | null;
+	sortBy?: 'createdAt' | 'updatedAt' | 'title';
+	sortOrder?: 'asc' | 'desc';
+	limit?: number;
+	offset?: number;
+}
+
+export interface NoteFolderFilter {
+	search?: string;
+	sortBy?: 'createdAt' | 'updatedAt' | 'name';
+	sortOrder?: 'asc' | 'desc';
+	limit?: number;
+	offset?: number;
+}


### PR DESCRIPTION
## Summary

Adds notes and note folders backend commands to the AFD Todo demo.

## New Commands

- \
ote-create\ - Create a new note
- \
ote-get\ - Get a note by ID
- \
ote-list\ - List notes with filtering
- \
ote-update\ - Update a note
- \
ote-delete\ - Delete a note
- \
otefolder-create\ - Create a note folder
- \
otefolder-get\ - Get a folder by ID
- \
otefolder-list\ - List folders
- \
otefolder-update\ - Update a folder
- \
otefolder-delete\ - Delete a folder

## AFD Compliance

- Standard CommandResult with reasoning and suggestion
- Proper Zod schema validation
- Mutations marked with \mutation: true\

Closes #75