### PR TITLE
feat(rust): add bootstrap commands and handoff support

### DIFF
--- a/packages/rust/src/bootstrap/afd_docs.rs
+++ b/packages/rust/src/bootstrap/afd_docs.rs
@@ -1,0 +1,261 @@
+//! afd-docs bootstrap command.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::commands::{
+    CommandContext, CommandDefinition, CommandHandler, CommandParameter, CommandRegistry,
+};
+use crate::result::{success_with, CommandResult, ResultOptions};
+
+use super::{BOOTSTRAP_CATEGORY, BOOTSTRAP_TAGS};
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DocsInput {
+    #[serde(default)]
+    pub command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocsOutput {
+    pub markdown: String,
+    pub command_count: usize,
+}
+
+pub struct AfdDocsHandler {
+    registry: Arc<CommandRegistry>,
+}
+
+impl AfdDocsHandler {
+    pub fn new(registry: Arc<CommandRegistry>) -> Self {
+        Self { registry }
+    }
+
+    fn generate_command_docs(&self, cmd: &CommandDefinition) -> String {
+        let mut lines: Vec<String> = Vec::new();
+        lines.push(format!("### `{}`", cmd.name));
+        lines.push(String::new());
+        lines.push(cmd.description.clone());
+        lines.push(String::new());
+
+        if let Some(tags) = &cmd.tags {
+            if !tags.is_empty() {
+                let tag_str = tags
+                    .iter()
+                    .map(|t| format!("`{}`", t))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                lines.push(format!("**Tags:** {}", tag_str));
+                lines.push(String::new());
+            }
+        }
+
+        lines.push(format!(
+            "**Mutation:** {}",
+            if cmd.mutation { "Yes" } else { "No (read-only)" }
+        ));
+        lines.push(String::new());
+
+        if !cmd.parameters.is_empty() {
+            lines.push("**Parameters:**".to_string());
+            lines.push(String::new());
+            lines.push("| Name | Type | Required | Description |".to_string());
+            lines.push("|------|------|----------|-------------|".to_string());
+            for param in &cmd.parameters {
+                let required = if param.required { "Yes" } else { "No" };
+                let type_str = format!("{:?}", param.param_type).to_lowercase();
+                lines.push(format!(
+                    "| {} | {} | {} | {} |",
+                    param.name, type_str, required, param.description
+                ));
+            }
+            lines.push(String::new());
+        }
+
+        lines.push("---".to_string());
+        lines.push(String::new());
+        lines.join("\n")
+    }
+}
+
+#[async_trait]
+impl CommandHandler for AfdDocsHandler {
+    async fn execute(
+        &self,
+        input: serde_json::Value,
+        _context: CommandContext,
+    ) -> CommandResult<serde_json::Value> {
+        let input: DocsInput = serde_json::from_value(input).unwrap_or_default();
+        let all_commands = self.registry.list();
+
+        let commands: Vec<_> = if let Some(ref cmd_name) = input.command {
+            all_commands
+                .into_iter()
+                .filter(|cmd| cmd.name == *cmd_name)
+                .collect()
+        } else {
+            all_commands
+        };
+
+        if input.command.is_some() && commands.is_empty() {
+            let output = DocsOutput {
+                markdown: String::new(),
+                command_count: 0,
+            };
+            return success_with(
+                serde_json::to_value(output).unwrap(),
+                ResultOptions {
+                    reasoning: Some(format!(
+                        "Command \"{}\" not found",
+                        input.command.unwrap()
+                    )),
+                    confidence: Some(1.0),
+                    ..Default::default()
+                },
+            );
+        }
+
+        let mut by_category: std::collections::HashMap<String, Vec<&Arc<CommandDefinition>>> =
+            std::collections::HashMap::new();
+        for cmd in &commands {
+            let category = cmd
+                .category
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(|| "General".to_string());
+            by_category.entry(category).or_default().push(cmd);
+        }
+
+        let mut lines: Vec<String> = Vec::new();
+        lines.push("# Command Documentation".to_string());
+        lines.push(String::new());
+
+        let mut categories: Vec<_> = by_category.keys().cloned().collect();
+        categories.sort();
+
+        for category in categories {
+            let cmds = by_category.get(&category).unwrap();
+            lines.push(format!("## {}", category));
+            lines.push(String::new());
+
+            let mut sorted_cmds: Vec<_> = cmds.iter().collect();
+            sorted_cmds.sort_by(|a, b| a.name.cmp(&b.name));
+
+            for cmd in sorted_cmds {
+                lines.push(self.generate_command_docs(cmd));
+            }
+        }
+
+        let markdown = lines.join("\n");
+        let command_count = commands.len();
+        let output = DocsOutput {
+            markdown,
+            command_count,
+        };
+
+        let reasoning = if let Some(cmd_name) = input.command {
+            format!("Generated documentation for \"{}\"", cmd_name)
+        } else {
+            format!("Generated documentation for {} commands", command_count)
+        };
+
+        success_with(
+            serde_json::to_value(output).unwrap(),
+            ResultOptions {
+                reasoning: Some(reasoning),
+                confidence: Some(1.0),
+                ..Default::default()
+            },
+        )
+    }
+}
+
+pub fn create_afd_docs_command(registry: Arc<CommandRegistry>) -> CommandDefinition {
+    CommandDefinition::new(
+        "afd-docs",
+        "Get detailed documentation for commands",
+        vec![CommandParameter::optional_string(
+            "command",
+            "Specific command name, or omit for all",
+        )],
+        AfdDocsHandler::new(registry),
+    )
+    .with_category(BOOTSTRAP_CATEGORY)
+    .with_tags(BOOTSTRAP_TAGS.iter().map(|s| s.to_string()).collect())
+    .with_version("1.0.0")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::result::success;
+
+    struct TestHandler;
+
+    #[async_trait]
+    impl CommandHandler for TestHandler {
+        async fn execute(
+            &self,
+            _input: serde_json::Value,
+            _context: CommandContext,
+        ) -> CommandResult<serde_json::Value> {
+            success(serde_json::json!({"test": true}))
+        }
+    }
+
+    fn create_test_registry() -> Arc<CommandRegistry> {
+        let mut registry = CommandRegistry::new();
+        let cmd1 = CommandDefinition::new(
+            "todo-create",
+            "Create a new todo item",
+            vec![
+                CommandParameter::required_string("title", "The todo title"),
+                CommandParameter::optional_string("description", "Optional description"),
+            ],
+            TestHandler,
+        )
+        .with_category("todo")
+        .with_tags(vec!["todo".to_string(), "write".to_string()])
+        .as_mutation();
+        let cmd2 = CommandDefinition::new("todo-list", "List all todos", vec![], TestHandler)
+            .with_category("todo")
+            .with_tags(vec!["todo".to_string(), "read".to_string()]);
+        registry.register(cmd1).unwrap();
+        registry.register(cmd2).unwrap();
+        Arc::new(registry)
+    }
+
+    #[tokio::test]
+    async fn test_afd_docs_all() {
+        let registry = create_test_registry();
+        let handler = AfdDocsHandler::new(registry);
+        let result = handler
+            .execute(serde_json::json!({}), CommandContext::new())
+            .await;
+        assert!(result.success);
+        let data = result.data.unwrap();
+        let output: DocsOutput = serde_json::from_value(data).unwrap();
+        assert_eq!(output.command_count, 2);
+        assert!(output.markdown.contains("# Command Documentation"));
+    }
+
+    #[tokio::test]
+    async fn test_afd_docs_not_found() {
+        let registry = create_test_registry();
+        let handler = AfdDocsHandler::new(registry);
+        let result = handler
+            .execute(
+                serde_json::json!({"command": "nonexistent"}),
+                CommandContext::new(),
+            )
+            .await;
+        assert!(result.success);
+        let data = result.data.unwrap();
+        let output: DocsOutput = serde_json::from_value(data).unwrap();
+        assert_eq!(output.command_count, 0);
+        assert!(output.markdown.is_empty());
+    }
+}

--- a/packages/rust/src/bootstrap/afd_help.rs
+++ b/packages/rust/src/bootstrap/afd_help.rs
@@ -1,0 +1,253 @@
+//! afd-help bootstrap command.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::commands::{
+    CommandContext, CommandDefinition, CommandHandler, CommandParameter, CommandRegistry,
+};
+use crate::result::{success_with, CommandResult, ResultOptions};
+
+use super::{BOOTSTRAP_CATEGORY, BOOTSTRAP_TAGS};
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct HelpInput {
+    #[serde(default)]
+    pub filter: Option<String>,
+    #[serde(default = "default_format")]
+    pub format: String,
+}
+
+fn default_format() -> String {
+    "brief".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandInfo {
+    pub name: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mutation: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HelpOutput {
+    pub commands: Vec<CommandInfo>,
+    pub total: usize,
+    pub filtered: bool,
+    pub grouped_by_category: HashMap<String, Vec<CommandInfo>>,
+}
+
+pub struct AfdHelpHandler {
+    registry: Arc<CommandRegistry>,
+}
+
+impl AfdHelpHandler {
+    pub fn new(registry: Arc<CommandRegistry>) -> Self {
+        Self { registry }
+    }
+}
+
+#[async_trait]
+impl CommandHandler for AfdHelpHandler {
+    async fn execute(
+        &self,
+        input: serde_json::Value,
+        _context: CommandContext,
+    ) -> CommandResult<serde_json::Value> {
+        let input: HelpInput = serde_json::from_value(input).unwrap_or_default();
+        let all_commands = self.registry.list();
+        let filtered = input.filter.is_some();
+
+        let commands: Vec<_> = if let Some(ref filter_text) = input.filter {
+            let filter_lower = filter_text.to_lowercase();
+            all_commands
+                .into_iter()
+                .filter(|cmd| {
+                    let tag_match = cmd
+                        .tags
+                        .as_ref()
+                        .map(|tags| tags.iter().any(|t| t.to_lowercase().contains(&filter_lower)))
+                        .unwrap_or(false);
+                    let category_match = cmd
+                        .category
+                        .as_ref()
+                        .map(|c| c.to_lowercase().contains(&filter_lower))
+                        .unwrap_or(false);
+                    let name_match = cmd.name.to_lowercase().contains(&filter_lower);
+                    tag_match || category_match || name_match
+                })
+                .collect()
+        } else {
+            all_commands
+        };
+
+        let is_full = input.format == "full";
+        let mut grouped_by_category: HashMap<String, Vec<CommandInfo>> = HashMap::new();
+        let mut command_infos: Vec<CommandInfo> = Vec::new();
+
+        for cmd in &commands {
+            let info = CommandInfo {
+                name: cmd.name.clone(),
+                description: cmd.description.clone(),
+                category: if is_full { cmd.category.clone() } else { None },
+                tags: if is_full { cmd.tags.clone() } else { None },
+                mutation: if is_full { Some(cmd.mutation) } else { None },
+            };
+            let category = cmd
+                .category
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(|| "uncategorized".to_string());
+            grouped_by_category
+                .entry(category)
+                .or_default()
+                .push(info.clone());
+            command_infos.push(info);
+        }
+
+        let total = command_infos.len();
+        let output = HelpOutput {
+            commands: command_infos,
+            total,
+            filtered,
+            grouped_by_category,
+        };
+
+        let reasoning = if filtered {
+            format!(
+                "Found {} commands matching \"{}\"",
+                total,
+                input.filter.unwrap_or_default()
+            )
+        } else {
+            format!("Listing all {} available commands", total)
+        };
+
+        success_with(
+            serde_json::to_value(output).unwrap(),
+            ResultOptions {
+                reasoning: Some(reasoning),
+                confidence: Some(1.0),
+                ..Default::default()
+            },
+        )
+    }
+}
+
+pub fn create_afd_help_command(registry: Arc<CommandRegistry>) -> CommandDefinition {
+    CommandDefinition::new(
+        "afd-help",
+        "List all available commands with tags and grouping",
+        vec![
+            CommandParameter::optional_string("filter", "Tag filter"),
+            CommandParameter::optional_string("format", "Output format")
+                .with_default(serde_json::json!("brief"))
+                .with_enum(vec![serde_json::json!("brief"), serde_json::json!("full")]),
+        ],
+        AfdHelpHandler::new(registry),
+    )
+    .with_category(BOOTSTRAP_CATEGORY)
+    .with_tags(BOOTSTRAP_TAGS.iter().map(|s| s.to_string()).collect())
+    .with_version("1.0.0")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::result::success;
+
+    struct TestHandler;
+
+    #[async_trait]
+    impl CommandHandler for TestHandler {
+        async fn execute(
+            &self,
+            _input: serde_json::Value,
+            _context: CommandContext,
+        ) -> CommandResult<serde_json::Value> {
+            success(serde_json::json!({"test": true}))
+        }
+    }
+
+    fn create_test_registry() -> Arc<CommandRegistry> {
+        let mut registry = CommandRegistry::new();
+        let cmd1 = CommandDefinition::new(
+            "todo-create",
+            "Create a new todo",
+            vec![CommandParameter::required_string("title", "Todo title")],
+            TestHandler,
+        )
+        .with_category("todo")
+        .with_tags(vec!["todo".to_string(), "write".to_string()])
+        .as_mutation();
+        let cmd2 = CommandDefinition::new("todo-list", "List all todos", vec![], TestHandler)
+            .with_category("todo")
+            .with_tags(vec!["todo".to_string(), "read".to_string()]);
+        let cmd3 = CommandDefinition::new(
+            "user-get",
+            "Get user by ID",
+            vec![CommandParameter::required_string("id", "User ID")],
+            TestHandler,
+        )
+        .with_category("user")
+        .with_tags(vec!["user".to_string(), "read".to_string()]);
+        registry.register(cmd1).unwrap();
+        registry.register(cmd2).unwrap();
+        registry.register(cmd3).unwrap();
+        Arc::new(registry)
+    }
+
+    #[tokio::test]
+    async fn test_afd_help_list_all() {
+        let registry = create_test_registry();
+        let handler = AfdHelpHandler::new(registry);
+        let result = handler
+            .execute(serde_json::json!({}), CommandContext::new())
+            .await;
+        assert!(result.success);
+        let data = result.data.unwrap();
+        let output: HelpOutput = serde_json::from_value(data).unwrap();
+        assert_eq!(output.total, 3);
+        assert!(!output.filtered);
+    }
+
+    #[tokio::test]
+    async fn test_afd_help_filter_by_tag() {
+        let registry = create_test_registry();
+        let handler = AfdHelpHandler::new(registry);
+        let result = handler
+            .execute(serde_json::json!({"filter": "todo"}), CommandContext::new())
+            .await;
+        assert!(result.success);
+        let data = result.data.unwrap();
+        let output: HelpOutput = serde_json::from_value(data).unwrap();
+        assert_eq!(output.total, 2);
+        assert!(output.filtered);
+    }
+
+    #[tokio::test]
+    async fn test_afd_help_grouped_by_category() {
+        let registry = create_test_registry();
+        let handler = AfdHelpHandler::new(registry);
+        let result = handler
+            .execute(serde_json::json!({}), CommandContext::new())
+            .await;
+        assert!(result.success);
+        let data = result.data.unwrap();
+        let output: HelpOutput = serde_json::from_value(data).unwrap();
+        assert!(output.grouped_by_category.contains_key("todo"));
+        assert!(output.grouped_by_category.contains_key("user"));
+        assert_eq!(output.grouped_by_category.get("todo").unwrap().len(), 2);
+        assert_eq!(output.grouped_by_category.get("user").unwrap().len(), 1);
+    }
+}

--- a/packages/rust/src/bootstrap/afd_schema.rs
+++ b/packages/rust/src/bootstrap/afd_schema.rs
@@ -1,0 +1,326 @@
+//! afd-schema bootstrap command.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::commands::{
+    command_to_mcp_tool, CommandContext, CommandDefinition, CommandHandler, CommandParameter,
+    CommandRegistry, JsonSchemaType, McpTool,
+};
+use crate::result::{success_with, CommandResult, ResultOptions};
+
+use super::{BOOTSTRAP_CATEGORY, BOOTSTRAP_TAGS};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum SchemaFormat {
+    Json,
+    Typescript,
+}
+
+impl Default for SchemaFormat {
+    fn default() -> Self {
+        SchemaFormat::Json
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaInput {
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub format: SchemaFormat,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaInfo {
+    pub name: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcp_tool: Option<McpTool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub typescript: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaOutput {
+    pub schemas: Vec<SchemaInfo>,
+    pub total: usize,
+    pub format: SchemaFormat,
+}
+
+pub struct AfdSchemaHandler {
+    registry: Arc<CommandRegistry>,
+}
+
+impl AfdSchemaHandler {
+    pub fn new(registry: Arc<CommandRegistry>) -> Self {
+        Self { registry }
+    }
+
+    fn generate_typescript_type(&self, cmd: &CommandDefinition) -> String {
+        let mut lines = Vec::new();
+        lines.push(format!("// {}", cmd.description));
+        lines.push(format!("interface {}Input {{", to_pascal_case(&cmd.name)));
+
+        for param in &cmd.parameters {
+            let ts_type = match param.param_type {
+                JsonSchemaType::String => "string".to_string(),
+                JsonSchemaType::Number | JsonSchemaType::Integer => "number".to_string(),
+                JsonSchemaType::Boolean => "boolean".to_string(),
+                JsonSchemaType::Array => "unknown[]".to_string(),
+                JsonSchemaType::Object => "Record<string, unknown>".to_string(),
+                JsonSchemaType::Null => "null".to_string(),
+            };
+            let optional = if param.required { "" } else { "?" };
+            lines.push(format!("  {}{}: {};", param.name, optional, ts_type));
+        }
+
+        lines.push("}".to_string());
+        lines.join("\n")
+    }
+}
+
+fn to_pascal_case(s: &str) -> String {
+    s.split(|c| c == '-' || c == '_' || c == '.')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => first.to_uppercase().chain(chars).collect(),
+            }
+        })
+        .collect()
+}
+
+#[async_trait]
+impl CommandHandler for AfdSchemaHandler {
+    async fn execute(
+        &self,
+        input: serde_json::Value,
+        _context: CommandContext,
+    ) -> CommandResult<serde_json::Value> {
+        let input: SchemaInput = serde_json::from_value(input).unwrap_or_default();
+        let all_commands = self.registry.list();
+
+        let commands: Vec<_> = if let Some(ref cmd_name) = input.command {
+            all_commands
+                .into_iter()
+                .filter(|cmd| cmd.name == *cmd_name)
+                .collect()
+        } else {
+            all_commands
+        };
+
+        if input.command.is_some() && commands.is_empty() {
+            let output = SchemaOutput {
+                schemas: vec![],
+                total: 0,
+                format: input.format,
+            };
+            return success_with(
+                serde_json::to_value(output).unwrap(),
+                ResultOptions {
+                    reasoning: Some(format!(
+                        "Command \"{}\" not found",
+                        input.command.unwrap()
+                    )),
+                    confidence: Some(1.0),
+                    ..Default::default()
+                },
+            );
+        }
+
+        let schemas: Vec<SchemaInfo> = commands
+            .iter()
+            .map(|cmd| {
+                let (mcp_tool, typescript) = match input.format {
+                    SchemaFormat::Json => (Some(command_to_mcp_tool(cmd)), None),
+                    SchemaFormat::Typescript => (None, Some(self.generate_typescript_type(cmd))),
+                };
+
+                SchemaInfo {
+                    name: cmd.name.clone(),
+                    description: cmd.description.clone(),
+                    mcp_tool,
+                    typescript,
+                }
+            })
+            .collect();
+
+        let total = schemas.len();
+        let output = SchemaOutput {
+            schemas,
+            total,
+            format: input.format.clone(),
+        };
+
+        let reasoning = if let Some(cmd_name) = input.command {
+            format!("Exported schema for \"{}\"", cmd_name)
+        } else {
+            format!("Exported {} command schemas", total)
+        };
+
+        success_with(
+            serde_json::to_value(output).unwrap(),
+            ResultOptions {
+                reasoning: Some(reasoning),
+                confidence: Some(1.0),
+                ..Default::default()
+            },
+        )
+    }
+}
+
+pub fn create_afd_schema_command(registry: Arc<CommandRegistry>) -> CommandDefinition {
+    CommandDefinition::new(
+        "afd-schema",
+        "Export JSON schemas for all commands",
+        vec![
+            CommandParameter::optional_string("command", "Specific command name, or omit for all"),
+            CommandParameter::optional_string("format", "Output format: json or typescript")
+                .with_default(serde_json::json!("json"))
+                .with_enum(vec![
+                    serde_json::json!("json"),
+                    serde_json::json!("typescript"),
+                ]),
+        ],
+        AfdSchemaHandler::new(registry),
+    )
+    .with_category(BOOTSTRAP_CATEGORY)
+    .with_tags(BOOTSTRAP_TAGS.iter().map(|s| s.to_string()).collect())
+    .with_version("1.0.0")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::result::success;
+
+    struct TestHandler;
+
+    #[async_trait]
+    impl CommandHandler for TestHandler {
+        async fn execute(
+            &self,
+            _input: serde_json::Value,
+            _context: CommandContext,
+        ) -> CommandResult<serde_json::Value> {
+            success(serde_json::json!({"test": true}))
+        }
+    }
+
+    fn create_test_registry() -> Arc<CommandRegistry> {
+        let mut registry = CommandRegistry::new();
+        let cmd = CommandDefinition::new(
+            "todo-create",
+            "Create a new todo item",
+            vec![
+                CommandParameter::required_string("title", "The todo title"),
+                CommandParameter::optional_string("description", "Optional description")
+                    .with_default(serde_json::json!(null)),
+                CommandParameter::required_string("priority", "Priority level")
+                    .with_enum(vec![
+                        serde_json::json!("low"),
+                        serde_json::json!("medium"),
+                        serde_json::json!("high"),
+                    ])
+                    .with_default(serde_json::json!("medium")),
+            ],
+            TestHandler,
+        )
+        .with_category("todo")
+        .as_mutation();
+        registry.register(cmd).unwrap();
+        Arc::new(registry)
+    }
+
+    #[tokio::test]
+    async fn test_afd_schema_json() {
+        let registry = create_test_registry();
+        let handler = AfdSchemaHandler::new(registry);
+        let result = handler
+            .execute(serde_json::json!({}), CommandContext::new())
+            .await;
+        assert!(result.success);
+        let data = result.data.unwrap();
+        let output: SchemaOutput = serde_json::from_value(data).unwrap();
+        assert_eq!(output.total, 1);
+        assert_eq!(output.format, SchemaFormat::Json);
+        assert!(output.schemas[0].mcp_tool.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_afd_schema_typescript() {
+        let registry = create_test_registry();
+        let handler = AfdSchemaHandler::new(registry);
+        let result = handler
+            .execute(
+                serde_json::json!({"format": "typescript"}),
+                CommandContext::new(),
+            )
+            .await;
+        assert!(result.success);
+        let data = result.data.unwrap();
+        let output: SchemaOutput = serde_json::from_value(data).unwrap();
+        assert_eq!(output.format, SchemaFormat::Typescript);
+        assert!(output.schemas[0].typescript.is_some());
+        let ts = output.schemas[0].typescript.as_ref().unwrap();
+        assert!(ts.contains("interface TodoCreateInput"));
+    }
+
+    #[tokio::test]
+    async fn test_afd_schema_includes_properties() {
+        let registry = create_test_registry();
+        let handler = AfdSchemaHandler::new(registry);
+        let result = handler
+            .execute(serde_json::json!({}), CommandContext::new())
+            .await;
+        assert!(result.success);
+        let data = result.data.unwrap();
+        let output: SchemaOutput = serde_json::from_value(data).unwrap();
+        let mcp = output.schemas[0].mcp_tool.as_ref().unwrap();
+        assert!(mcp.input_schema.properties.contains_key("title"));
+        assert!(mcp.input_schema.properties.contains_key("description"));
+        assert!(mcp.input_schema.properties.contains_key("priority"));
+    }
+
+    #[tokio::test]
+    async fn test_afd_schema_includes_enum_and_default() {
+        let registry = create_test_registry();
+        let handler = AfdSchemaHandler::new(registry);
+        let result = handler
+            .execute(serde_json::json!({}), CommandContext::new())
+            .await;
+        assert!(result.success);
+        let data = result.data.unwrap();
+        let output: SchemaOutput = serde_json::from_value(data).unwrap();
+        let mcp = output.schemas[0].mcp_tool.as_ref().unwrap();
+        let priority = mcp.input_schema.properties.get("priority").unwrap();
+        assert!(priority.enum_values.is_some());
+        assert!(priority.default.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_afd_schema_empty_parameters() {
+        let mut registry = CommandRegistry::new();
+        let cmd = CommandDefinition::new("todo-list", "List all todos", vec![], TestHandler);
+        registry.register(cmd).unwrap();
+        let registry = Arc::new(registry);
+
+        let handler = AfdSchemaHandler::new(registry);
+        let result = handler
+            .execute(serde_json::json!({}), CommandContext::new())
+            .await;
+        assert!(result.success);
+        let data = result.data.unwrap();
+        let output: SchemaOutput = serde_json::from_value(data).unwrap();
+        let mcp = output.schemas[0].mcp_tool.as_ref().unwrap();
+        assert!(mcp.input_schema.properties.is_empty());
+        assert!(mcp.input_schema.required.is_empty());
+    }
+}

--- a/packages/rust/src/bootstrap/mod.rs
+++ b/packages/rust/src/bootstrap/mod.rs
@@ -1,0 +1,33 @@
+//! Bootstrap commands for AFD servers.
+//!
+//! Bootstrap commands provide introspection and documentation capabilities
+//! for any AFD server. They are automatically available on all servers.
+
+mod afd_docs;
+mod afd_help;
+mod afd_schema;
+
+pub use afd_docs::{create_afd_docs_command, AfdDocsHandler, DocsInput, DocsOutput};
+pub use afd_help::{create_afd_help_command, AfdHelpHandler, CommandInfo, HelpInput, HelpOutput};
+pub use afd_schema::{
+    create_afd_schema_command, AfdSchemaHandler, SchemaFormat, SchemaInfo, SchemaInput,
+    SchemaOutput,
+};
+
+use crate::commands::{CommandDefinition, CommandRegistry};
+use std::sync::Arc;
+
+/// Get all bootstrap commands for an AFD server.
+pub fn get_bootstrap_commands(registry: &Arc<CommandRegistry>) -> Vec<CommandDefinition> {
+    vec![
+        create_afd_help_command(Arc::clone(registry)),
+        create_afd_docs_command(Arc::clone(registry)),
+        create_afd_schema_command(Arc::clone(registry)),
+    ]
+}
+
+/// Bootstrap command category name.
+pub const BOOTSTRAP_CATEGORY: &str = "bootstrap";
+
+/// Bootstrap command tags.
+pub const BOOTSTRAP_TAGS: &[&str] = &["bootstrap", "read", "safe"];

--- a/packages/rust/src/handoff.rs
+++ b/packages/rust/src/handoff.rs
@@ -1,0 +1,586 @@
+//! # Handoff Protocol Types
+//!
+//! Types and utilities for protocol handoff in AFD.
+//!
+//! Protocol handoff enables commands to establish real-time connections
+//! (WebSocket, WebRTC, SSE, etc.) by returning connection details.
+//!
+//! ## Example
+//!
+//! ```rust
+//! use afd::handoff::{HandoffResult, HandoffProtocol, HandoffCredentials, HandoffMetadata};
+//!
+//! // Create a WebSocket handoff
+//! let handoff = HandoffResult::new(HandoffProtocol::Websocket, "wss://api.example.com/ws")
+//!     .with_credentials(HandoffCredentials::new().with_token("jwt-token-here"))
+//!     .with_metadata(HandoffMetadata::new().with_description("Real-time updates"));
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// HANDOFF PROTOCOL
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Supported handoff protocols.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HandoffProtocol {
+    /// WebSocket protocol (ws:// or wss://)
+    Websocket,
+    /// WebRTC peer connection
+    Webrtc,
+    /// Server-Sent Events
+    Sse,
+    /// HTTP streaming
+    #[serde(rename = "http-stream")]
+    HttpStream,
+    /// Custom protocol with identifier
+    #[serde(untagged)]
+    Custom(String),
+}
+
+impl HandoffProtocol {
+    /// Get the protocol as a string.
+    pub fn as_str(&self) -> &str {
+        match self {
+            HandoffProtocol::Websocket => "websocket",
+            HandoffProtocol::Webrtc => "webrtc",
+            HandoffProtocol::Sse => "sse",
+            HandoffProtocol::HttpStream => "http-stream",
+            HandoffProtocol::Custom(s) => s.as_str(),
+        }
+    }
+}
+
+impl std::fmt::Display for HandoffProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// HANDOFF CREDENTIALS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Credentials for authenticating the handoff connection.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffCredentials {
+    /// Authentication token (JWT, API key, etc.)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+
+    /// Additional headers for the connection
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<HashMap<String, String>>,
+
+    /// Session identifier for reconnection
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+impl HandoffCredentials {
+    /// Create new empty credentials.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the authentication token.
+    pub fn with_token(mut self, token: impl Into<String>) -> Self {
+        self.token = Some(token.into());
+        self
+    }
+
+    /// Set additional headers.
+    pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.headers = Some(headers);
+        self
+    }
+
+    /// Add a single header.
+    pub fn with_header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        let headers = self.headers.get_or_insert_with(HashMap::new);
+        headers.insert(key.into(), value.into());
+        self
+    }
+
+    /// Set the session ID.
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RECONNECT POLICY
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Policy for reconnecting to a handoff endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconnectPolicy {
+    /// Whether reconnection is allowed
+    pub allowed: bool,
+
+    /// Maximum number of reconnection attempts
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_attempts: Option<u32>,
+
+    /// Backoff delay in milliseconds between attempts
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backoff_ms: Option<u32>,
+}
+
+impl Default for ReconnectPolicy {
+    fn default() -> Self {
+        Self {
+            allowed: true,
+            max_attempts: Some(3),
+            backoff_ms: Some(1000),
+        }
+    }
+}
+
+impl ReconnectPolicy {
+    /// Create a new reconnect policy.
+    pub fn new(allowed: bool) -> Self {
+        Self {
+            allowed,
+            max_attempts: None,
+            backoff_ms: None,
+        }
+    }
+
+    /// Set maximum reconnection attempts.
+    pub fn with_max_attempts(mut self, max: u32) -> Self {
+        self.max_attempts = Some(max);
+        self
+    }
+
+    /// Set backoff delay in milliseconds.
+    pub fn with_backoff_ms(mut self, ms: u32) -> Self {
+        self.backoff_ms = Some(ms);
+        self
+    }
+
+    /// Create a policy that disallows reconnection.
+    pub fn no_reconnect() -> Self {
+        Self::new(false)
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// HANDOFF METADATA
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Additional metadata about the handoff connection.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffMetadata {
+    /// Expected latency in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_latency: Option<u32>,
+
+    /// Capabilities supported by the endpoint
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Vec<String>>,
+
+    /// ISO 8601 timestamp when the handoff expires
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+
+    /// Reconnection policy
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reconnect: Option<ReconnectPolicy>,
+
+    /// Human-readable description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl HandoffMetadata {
+    /// Create new empty metadata.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set expected latency in milliseconds.
+    pub fn with_expected_latency(mut self, ms: u32) -> Self {
+        self.expected_latency = Some(ms);
+        self
+    }
+
+    /// Set capabilities.
+    pub fn with_capabilities(mut self, caps: Vec<String>) -> Self {
+        self.capabilities = Some(caps);
+        self
+    }
+
+    /// Add a capability.
+    pub fn with_capability(mut self, cap: impl Into<String>) -> Self {
+        let caps = self.capabilities.get_or_insert_with(Vec::new);
+        caps.push(cap.into());
+        self
+    }
+
+    /// Set expiration timestamp (ISO 8601).
+    pub fn with_expires_at(mut self, expires: impl Into<String>) -> Self {
+        self.expires_at = Some(expires.into());
+        self
+    }
+
+    /// Set reconnect policy.
+    pub fn with_reconnect(mut self, policy: ReconnectPolicy) -> Self {
+        self.reconnect = Some(policy);
+        self
+    }
+
+    /// Set description.
+    pub fn with_description(mut self, desc: impl Into<String>) -> Self {
+        self.description = Some(desc.into());
+        self
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// HANDOFF RESULT
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Result type for protocol handoff operations.
+///
+/// A `HandoffResult` provides all the information needed for a client
+/// to establish a real-time connection to a service endpoint.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffResult {
+    /// The protocol to use for the connection
+    pub protocol: HandoffProtocol,
+
+    /// The endpoint URL to connect to
+    pub endpoint: String,
+
+    /// Optional credentials for authentication
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<HandoffCredentials>,
+
+    /// Optional metadata about the connection
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HandoffMetadata>,
+}
+
+impl HandoffResult {
+    /// Create a new handoff result.
+    pub fn new(protocol: HandoffProtocol, endpoint: impl Into<String>) -> Self {
+        Self {
+            protocol,
+            endpoint: endpoint.into(),
+            credentials: None,
+            metadata: None,
+        }
+    }
+
+    /// Create a WebSocket handoff.
+    pub fn websocket(endpoint: impl Into<String>) -> Self {
+        Self::new(HandoffProtocol::Websocket, endpoint)
+    }
+
+    /// Create a WebRTC handoff.
+    pub fn webrtc(endpoint: impl Into<String>) -> Self {
+        Self::new(HandoffProtocol::Webrtc, endpoint)
+    }
+
+    /// Create an SSE handoff.
+    pub fn sse(endpoint: impl Into<String>) -> Self {
+        Self::new(HandoffProtocol::Sse, endpoint)
+    }
+
+    /// Create an HTTP streaming handoff.
+    pub fn http_stream(endpoint: impl Into<String>) -> Self {
+        Self::new(HandoffProtocol::HttpStream, endpoint)
+    }
+
+    /// Set credentials.
+    pub fn with_credentials(mut self, credentials: HandoffCredentials) -> Self {
+        self.credentials = Some(credentials);
+        self
+    }
+
+    /// Set metadata.
+    pub fn with_metadata(mut self, metadata: HandoffMetadata) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TYPE GUARDS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Check if a JSON value is a valid handoff result.
+///
+/// Returns true if the value has the required `protocol` and `endpoint` fields.
+pub fn is_handoff(value: &serde_json::Value) -> bool {
+    value.get("protocol").is_some() && value.get("endpoint").is_some()
+}
+
+/// Check if a string is a valid handoff protocol.
+pub fn is_handoff_protocol(protocol: &str) -> bool {
+    matches!(
+        protocol.to_lowercase().as_str(),
+        "websocket" | "webrtc" | "sse" | "http-stream"
+    )
+}
+
+/// Trait for types that may be handoff commands.
+pub trait HandoffCommandLike {
+    /// Check if this is a handoff command.
+    fn is_handoff(&self) -> bool;
+
+    /// Get the handoff protocol if specified.
+    fn handoff_protocol(&self) -> Option<&str>;
+
+    /// Get the command tags.
+    fn tags(&self) -> Option<&[String]>;
+}
+
+/// Check if a command definition is a handoff command.
+///
+/// A command is considered a handoff command if:
+/// - It has `handoff: true`, or
+/// - It has a `handoff_protocol` specified, or
+/// - It has "handoff" in its tags
+pub fn is_handoff_command<T: HandoffCommandLike>(command: &T) -> bool {
+    command.is_handoff()
+        || command.handoff_protocol().is_some()
+        || command
+            .tags()
+            .map(|t| t.iter().any(|tag| tag == "handoff"))
+            .unwrap_or(false)
+}
+
+/// Get the handoff protocol from a command if it's a handoff command.
+pub fn get_handoff_protocol<T: HandoffCommandLike>(command: &T) -> Option<&str> {
+    if is_handoff_command(command) {
+        command.handoff_protocol()
+    } else {
+        None
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// HELPER FUNCTIONS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Check if a handoff has expired based on its metadata.
+///
+/// Returns `true` if the handoff has an `expires_at` timestamp that is in the past.
+/// Returns `false` if there's no expiration or if the timestamp can't be parsed.
+pub fn is_handoff_expired(handoff: &HandoffResult) -> bool {
+    let Some(metadata) = &handoff.metadata else {
+        return false;
+    };
+    let Some(expires_at) = &metadata.expires_at else {
+        return false;
+    };
+
+    // Try to parse ISO 8601 timestamp
+    if let Ok(expires) = chrono::DateTime::parse_from_rfc3339(expires_at) {
+        expires < chrono::Utc::now()
+    } else {
+        false
+    }
+}
+
+/// Get the time-to-live in seconds for a handoff.
+///
+/// Returns `Some(seconds)` if the handoff has an `expires_at` timestamp in the future.
+/// Returns `None` if there's no expiration, if it's already expired, or if the timestamp can't be parsed.
+pub fn get_handoff_ttl(handoff: &HandoffResult) -> Option<u64> {
+    let metadata = handoff.metadata.as_ref()?;
+    let expires_at = metadata.expires_at.as_ref()?;
+
+    let expires = chrono::DateTime::parse_from_rfc3339(expires_at).ok()?;
+    let now = chrono::Utc::now();
+
+    if expires > now {
+        Some((expires.timestamp() - now.timestamp()) as u64)
+    } else {
+        None
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TESTS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_handoff_protocol_serialization() {
+        assert_eq!(
+            serde_json::to_string(&HandoffProtocol::Websocket).unwrap(),
+            "\"websocket\""
+        );
+        assert_eq!(
+            serde_json::to_string(&HandoffProtocol::HttpStream).unwrap(),
+            "\"http-stream\""
+        );
+    }
+
+    #[test]
+    fn test_handoff_result_builder() {
+        let handoff = HandoffResult::websocket("wss://example.com/ws")
+            .with_credentials(HandoffCredentials::new().with_token("test-token"))
+            .with_metadata(HandoffMetadata::new().with_description("Test connection"));
+
+        assert_eq!(handoff.protocol, HandoffProtocol::Websocket);
+        assert_eq!(handoff.endpoint, "wss://example.com/ws");
+        assert_eq!(
+            handoff.credentials.as_ref().unwrap().token,
+            Some("test-token".to_string())
+        );
+        assert_eq!(
+            handoff.metadata.as_ref().unwrap().description,
+            Some("Test connection".to_string())
+        );
+    }
+
+    #[test]
+    fn test_handoff_credentials_builder() {
+        let creds = HandoffCredentials::new()
+            .with_token("jwt-token")
+            .with_session_id("session-123")
+            .with_header("X-Custom", "value");
+
+        assert_eq!(creds.token, Some("jwt-token".to_string()));
+        assert_eq!(creds.session_id, Some("session-123".to_string()));
+        assert_eq!(
+            creds.headers.as_ref().unwrap().get("X-Custom"),
+            Some(&"value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_handoff_metadata_builder() {
+        let meta = HandoffMetadata::new()
+            .with_expected_latency(50)
+            .with_capability("streaming")
+            .with_capability("bidirectional")
+            .with_reconnect(ReconnectPolicy::default());
+
+        assert_eq!(meta.expected_latency, Some(50));
+        assert_eq!(
+            meta.capabilities,
+            Some(vec!["streaming".to_string(), "bidirectional".to_string()])
+        );
+        assert!(meta.reconnect.is_some());
+    }
+
+    #[test]
+    fn test_reconnect_policy() {
+        let policy = ReconnectPolicy::new(true)
+            .with_max_attempts(5)
+            .with_backoff_ms(2000);
+
+        assert!(policy.allowed);
+        assert_eq!(policy.max_attempts, Some(5));
+        assert_eq!(policy.backoff_ms, Some(2000));
+
+        let no_reconnect = ReconnectPolicy::no_reconnect();
+        assert!(!no_reconnect.allowed);
+    }
+
+    #[test]
+    fn test_is_handoff_type_guard() {
+        let valid = serde_json::json!({
+            "protocol": "websocket",
+            "endpoint": "wss://example.com"
+        });
+        assert!(is_handoff(&valid));
+
+        let missing_protocol = serde_json::json!({
+            "endpoint": "wss://example.com"
+        });
+        assert!(!is_handoff(&missing_protocol));
+
+        let missing_endpoint = serde_json::json!({
+            "protocol": "websocket"
+        });
+        assert!(!is_handoff(&missing_endpoint));
+    }
+
+    #[test]
+    fn test_is_handoff_protocol() {
+        assert!(is_handoff_protocol("websocket"));
+        assert!(is_handoff_protocol("WEBSOCKET"));
+        assert!(is_handoff_protocol("webrtc"));
+        assert!(is_handoff_protocol("sse"));
+        assert!(is_handoff_protocol("http-stream"));
+        assert!(!is_handoff_protocol("invalid"));
+        assert!(!is_handoff_protocol("custom"));
+    }
+
+    #[test]
+    fn test_handoff_json_serialization() {
+        let handoff = HandoffResult::websocket("wss://api.example.com/ws")
+            .with_credentials(HandoffCredentials::new().with_token("token"))
+            .with_metadata(
+                HandoffMetadata::new()
+                    .with_expires_at("2025-12-31T23:59:59Z")
+                    .with_reconnect(ReconnectPolicy::default()),
+            );
+
+        let json = serde_json::to_string(&handoff).unwrap();
+
+        // Verify camelCase serialization
+        assert!(json.contains("\"protocol\":\"websocket\""));
+        assert!(json.contains("\"endpoint\":"));
+        assert!(json.contains("\"expiresAt\":"));
+        assert!(json.contains("\"maxAttempts\":"));
+        assert!(json.contains("\"backoffMs\":"));
+    }
+
+    #[test]
+    fn test_handoff_expired() {
+        // Not expired (no metadata)
+        let handoff = HandoffResult::websocket("wss://example.com");
+        assert!(!is_handoff_expired(&handoff));
+
+        // Not expired (no expires_at)
+        let handoff = HandoffResult::websocket("wss://example.com")
+            .with_metadata(HandoffMetadata::new().with_description("test"));
+        assert!(!is_handoff_expired(&handoff));
+
+        // Expired
+        let handoff = HandoffResult::websocket("wss://example.com")
+            .with_metadata(HandoffMetadata::new().with_expires_at("2020-01-01T00:00:00Z"));
+        assert!(is_handoff_expired(&handoff));
+
+        // Not expired (future date)
+        let handoff = HandoffResult::websocket("wss://example.com")
+            .with_metadata(HandoffMetadata::new().with_expires_at("2099-12-31T23:59:59Z"));
+        assert!(!is_handoff_expired(&handoff));
+    }
+
+    #[test]
+    fn test_get_handoff_ttl() {
+        // No TTL (no metadata)
+        let handoff = HandoffResult::websocket("wss://example.com");
+        assert!(get_handoff_ttl(&handoff).is_none());
+
+        // No TTL (expired)
+        let handoff = HandoffResult::websocket("wss://example.com")
+            .with_metadata(HandoffMetadata::new().with_expires_at("2020-01-01T00:00:00Z"));
+        assert!(get_handoff_ttl(&handoff).is_none());
+
+        // Has TTL (future date)
+        let handoff = HandoffResult::websocket("wss://example.com")
+            .with_metadata(HandoffMetadata::new().with_expires_at("2099-12-31T23:59:59Z"));
+        assert!(get_handoff_ttl(&handoff).is_some());
+        assert!(get_handoff_ttl(&handoff).unwrap() > 0);
+    }
+}

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -36,8 +36,10 @@
 
 // Module declarations
 pub mod batch;
+pub mod bootstrap;
 pub mod commands;
 pub mod errors;
+pub mod handoff;
 pub mod metadata;
 pub mod pipeline;
 pub mod result;
@@ -113,6 +115,26 @@ pub use pipeline::{
     PipelineContext, PipelineMetadata, PipelineOptions, PipelineRequest, PipelineResult,
     PipelineSource, PipelineStep, PipelineWarning, StepConfidence, StepMetadata, StepReasoning,
     StepResult, StepStatus,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RE-EXPORTS: Bootstrap types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+pub use bootstrap::{
+    get_bootstrap_commands, AfdDocsHandler, AfdHelpHandler, AfdSchemaHandler, CommandInfo,
+    DocsInput, DocsOutput, HelpInput, HelpOutput, SchemaFormat, SchemaInfo, SchemaInput,
+    SchemaOutput, BOOTSTRAP_CATEGORY, BOOTSTRAP_TAGS,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RE-EXPORTS: Handoff types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+pub use handoff::{
+    get_handoff_protocol, get_handoff_ttl, is_handoff, is_handoff_command, is_handoff_expired,
+    is_handoff_protocol, HandoffCommandLike, HandoffCredentials, HandoffMetadata, HandoffProtocol,
+    HandoffResult, ReconnectPolicy,
 };
 
 /// Crate version.


### PR DESCRIPTION
## Summary

Adds bootstrap module with server introspection commands and handoff protocol support for the Rust AFD crate.

### Bootstrap Commands
- **afd-help**: List available commands with filtering by tag/category/name and grouping by category
- **afd-docs**: Generate markdown documentation for commands  
- **afd-schema**: Export JSON schemas or TypeScript type definitions

### Handoff Support
- `HandoffResult`, `HandoffProtocol`, `HandoffCredentials`, `HandoffMetadata` types
- Support for websocket, webrtc, sse, http-stream protocols
- `HandoffCommandLike` trait for command introspection
- Helper functions: `is_handoff_expired()`, `get_handoff_ttl()`

### CommandDefinition Enhancements
- `with_tags()` - Set tags for categorization
- `with_version()` - Set command version
- `as_handoff()` / `as_handoff_with_protocol()` - Mark as handoff command
- `list_handoff_commands()` on CommandRegistry

## Test plan
- [x] All 80 unit tests pass
- [x] All 17 doc tests pass
- [x] Bootstrap commands tested: filtering, grouping, schema generation
- [x] Handoff types tested: builder patterns, serialization, TTL/expiry

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)