### PR TITLE
feat(demos/todo): configure Vitest for frontend testing

### DIFF
--- a/demos/todo/frontend/package.json
+++ b/demos/todo/frontend/package.json
@@ -7,15 +7,23 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@tiptap/pm": "^3.15.3",
+    "@tiptap/react": "^3.15.3",
+    "@tiptap/starter-kit": "^3.15.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
@@ -24,8 +32,10 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^27.0.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/demos/todo/frontend/src/setupTests.ts
+++ b/demos/todo/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/demos/todo/frontend/vitest.config.ts
+++ b/demos/todo/frontend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/setupTests.ts'],
+  },
+})


### PR DESCRIPTION
## Summary
- Installs Vitest and testing dependencies in `demos/todo/frontend`
- Creates `vitest.config.ts` with React and jsdom environment support
- Adds test scripts to package.json

## Test plan
- [x] Install dependencies: `npm install -D vitest @testing-library/react @testing-library/jest-dom jsdom`
- [x] Create vitest.config.ts with React plugin and jsdom environment
- [x] Add setupTests.ts for @testing-library/jest-dom setup
- [x] Add test scripts to package.json (test, test:watch, test:ui)
- [x] Verify Vitest runs without errors (no test files found is expected)

## Implementation Details

**Dependencies installed:**
- `vitest` - Fast unit test framework
- `@testing-library/react` - React component testing utilities
- `@testing-library/jest-dom` - Custom Jest matchers for DOM
- `jsdom` - DOM environment for tests

**Configuration files:**
- `vitest.config.ts` - Vitest configuration with React plugin and jsdom environment
- `src/setupTests.ts` - Test setup file that imports jest-dom matchers

**Package.json scripts added:**
- `test` - Run tests once
- `test:watch` - Run tests in watch mode
- `test:ui` - Run tests with UI interface

This completes Task 0.2 for issue #117 (Forge Chat Sidebar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)