### PR TITLE
feat(demos/todo): add Playwright end-to-end testing setup

### DIFF
--- a/demos/todo/frontend/e2e/example.spec.ts
+++ b/demos/todo/frontend/e2e/example.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage loads successfully', async ({ page }) => {
+  await page.goto('/');
+
+  // Check that the page loads and has a title
+  await expect(page).toHaveTitle(/AFD Todo/i);
+
+  // Check for main content area
+  await expect(page.locator('body')).toBeVisible();
+});

--- a/demos/todo/frontend/package.json
+++ b/demos/todo/frontend/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:watch": "vitest --watch",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tiptap/pm": "^3.15.3",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.57.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@types/node": "^24.10.1",

--- a/demos/todo/frontend/playwright.config.ts
+++ b/demos/todo/frontend/playwright.config.ts
@@ -1,0 +1,71 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:5173',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
- Install @playwright/test as dev dependency in demos/todo/frontend
- Configure Playwright to test against localhost:5173
- Add npm script test:e2e for running end-to-end tests  
- Include example test to validate homepage functionality

## Test plan
- [x] Package.json includes @playwright/test dependency
- [x] Playwright config points to correct localhost URL
- [x] Test script added to package.json
- [x] Example test file created in e2e/ directory
- [ ] Verify tests run successfully with `npm run test:e2e`

This completes Task 0.1 for issue #117 (Forge Chat Sidebar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)