### PR TITLE
feat(chat): Wave 1.3 - Markdown rendering for chat messages

### DIFF
--- a/demos/todo/frontend/src/components/ChatSidebar.css
+++ b/demos/todo/frontend/src/components/ChatSidebar.css
@@ -310,3 +310,129 @@
     right: -100%;
   }
 }
+
+/* Markdown Message Styles */
+.markdown-message {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+/* Markdown Headings */
+.markdown-h1, .markdown-h2, .markdown-h3,
+.markdown-h4, .markdown-h5, .markdown-h6 {
+  margin: 0.5rem 0 0.25rem 0;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.markdown-h1 { font-size: 1.2rem; }
+.markdown-h2 { font-size: 1.1rem; }
+.markdown-h3 { font-size: 1.05rem; }
+.markdown-h4, .markdown-h5, .markdown-h6 { font-size: 1rem; }
+
+/* Markdown Paragraphs */
+.markdown-p {
+  margin: 0.25rem 0;
+  line-height: 1.5;
+}
+
+.markdown-p:first-child {
+  margin-top: 0;
+}
+
+.markdown-p:last-child {
+  margin-bottom: 0;
+}
+
+/* Markdown Lists */
+.markdown-ul, .markdown-ol {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.markdown-li {
+  margin: 0.125rem 0;
+  line-height: 1.4;
+}
+
+/* Markdown Inline Code */
+.inline-code {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 0.125rem 0.25rem;
+  border-radius: 3px;
+  font-family: 'Monaco', 'Consolas', monospace;
+  font-size: 0.85em;
+}
+
+.chat-message.user .inline-code {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.chat-message.assistant .inline-code {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+/* Markdown Code Blocks */
+.markdown-code-block {
+  background: rgba(0, 0, 0, 0.8);
+  padding: 1rem;
+  border-radius: 6px;
+  margin: 0.5rem 0;
+  overflow-x: auto;
+  font-family: 'Monaco', 'Consolas', monospace;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.markdown-code-block code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  color: #f8f8f2;
+}
+
+.chat-message.user .markdown-code-block {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.chat-message.assistant .markdown-code-block {
+  background: rgba(0, 0, 0, 0.8);
+}
+
+/* Markdown Blockquotes */
+.markdown-blockquote {
+  border-left: 3px solid var(--border);
+  padding-left: 1rem;
+  margin: 0.5rem 0;
+  font-style: italic;
+  opacity: 0.8;
+}
+
+/* Markdown Links */
+.markdown-link {
+  color: inherit;
+  text-decoration: underline;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+}
+
+.markdown-link:hover {
+  opacity: 1;
+}
+
+/* Markdown Emphasis */
+.markdown-strong {
+  font-weight: 600;
+}
+
+.markdown-em {
+  font-style: italic;
+}
+
+/* Markdown Horizontal Rule */
+.markdown-hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 0.75rem 0;
+  opacity: 0.5;
+}

--- a/demos/todo/frontend/src/components/ChatSidebar.tsx
+++ b/demos/todo/frontend/src/components/ChatSidebar.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import './ChatSidebar.css';
+import { MarkdownMessage } from './MarkdownMessage';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // TYPES
@@ -195,7 +196,7 @@ export const ChatSidebar: React.FC<ChatSidebarProps> = ({
 				<div className="chat-messages">
 					{messages.map((msg) => (
 						<div key={msg.id} className={`chat-message ${msg.role}`}>
-							<div className="chat-message-content">{msg.content}</div>
+							<MarkdownMessage content={msg.content} className="chat-message-content" />
 
 							{/* Tool Executions */}
 							{msg.toolExecutions && msg.toolExecutions.length > 0 && (

--- a/demos/todo/frontend/src/components/MarkdownMessage.tsx
+++ b/demos/todo/frontend/src/components/MarkdownMessage.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+
+interface MarkdownMessageProps {
+	content: string;
+	className?: string;
+}
+
+export const MarkdownMessage: React.FC<MarkdownMessageProps> = ({ content, className = '' }) => {
+	return (
+		<div className={`markdown-message ${className}`}>
+			<ReactMarkdown
+				components={{
+					code({ className, children, ...props }) {
+						const match = /language-(\w+)/.exec(className || '');
+						const language = match ? match[1] : '';
+
+						// Check if this is a code block (has language) vs inline code
+						const isCodeBlock = language && typeof children === 'string' && children.includes('\n');
+
+						return isCodeBlock ? (
+							<pre className="markdown-code-block">
+								<code className={`language-${language}`} {...props}>
+									{String(children).replace(/\n$/, '')}
+								</code>
+							</pre>
+						) : (
+							<code className={`inline-code ${className || ''}`} {...props}>
+								{children}
+							</code>
+						);
+					},
+					h1({ children }) {
+						return <h1 className="markdown-h1">{children}</h1>;
+					},
+					h2({ children }) {
+						return <h2 className="markdown-h2">{children}</h2>;
+					},
+					h3({ children }) {
+						return <h3 className="markdown-h3">{children}</h3>;
+					},
+					h4({ children }) {
+						return <h4 className="markdown-h4">{children}</h4>;
+					},
+					h5({ children }) {
+						return <h5 className="markdown-h5">{children}</h5>;
+					},
+					h6({ children }) {
+						return <h6 className="markdown-h6">{children}</h6>;
+					},
+					p({ children }) {
+						return <p className="markdown-p">{children}</p>;
+					},
+					ul({ children }) {
+						return <ul className="markdown-ul">{children}</ul>;
+					},
+					ol({ children }) {
+						return <ol className="markdown-ol">{children}</ol>;
+					},
+					li({ children }) {
+						return <li className="markdown-li">{children}</li>;
+					},
+					blockquote({ children }) {
+						return <blockquote className="markdown-blockquote">{children}</blockquote>;
+					},
+					strong({ children }) {
+						return <strong className="markdown-strong">{children}</strong>;
+					},
+					em({ children }) {
+						return <em className="markdown-em">{children}</em>;
+					},
+					a({ href, children }) {
+						return (
+							<a
+								href={href}
+								className="markdown-link"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{children}
+							</a>
+						);
+					},
+					hr() {
+						return <hr className="markdown-hr" />;
+					},
+				}}
+			>
+				{content}
+			</ReactMarkdown>
+		</div>
+	);
+};
+
+export default MarkdownMessage;


### PR DESCRIPTION
## Summary
Implements Wave 1.3 of the Forge Chat Sidebar MVP - adding markdown rendering to chat messages.

- ✅ Added MarkdownMessage component with safe rendering using react-markdown  
- ✅ Replaced plain text content with markdown-rendered messages
- ✅ Added comprehensive CSS styling for all markdown elements
- ✅ Code blocks with dark theme styling and syntax highlighting structure
- ✅ All markdown elements styled to match chat sidebar theme

## Test plan
- [x] Build passes without markdown-related TypeScript errors
- [x] Component properly renders markdown content
- [x] All markdown elements (headings, lists, code, links, etc.) are styled
- [x] Inline code and code blocks have appropriate styling
- [x] Responsive design maintained

## Changes
### New Components
- `src/components/MarkdownMessage.tsx` - React component for safe markdown rendering

### Modified Components  
- `src/components/ChatSidebar.tsx` - Updated to use MarkdownMessage component
- `src/components/ChatSidebar.css` - Added comprehensive markdown styling

### Dependencies
- Added `react-markdown` for safe markdown rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)