### PR TITLE
feat(core): add command prerequisites with requires field

### DIFF
--- a/.claude/skills/afd-typescript/SKILL.md
+++ b/.claude/skills/afd-typescript/SKILL.md
@@ -45,6 +45,7 @@ export const createTodo = defineCommand({
   description: 'Create a new todo item',
   category: 'todo',
   mutation: true,
+  requires: ['auth-sign-in'],  // Planning-order dependency (metadata only)
   version: '1.0.0',
   input: inputSchema,
   errors: ['VALIDATION_ERROR'],

--- a/.claude/skills/afd/SKILL.md
+++ b/.claude/skills/afd/SKILL.md
@@ -47,6 +47,7 @@ Expert guidance for building software with the Agent-First Development methodolo
 | Destructive commands, confirmation UI | [references/command-trust-config.md](references/command-trust-config.md) |
 | Interface exposure, undo metadata | [references/command-exposure-undo.md](references/command-exposure-undo.md) |
 | Cross-platform exec, connectors | [references/platform-utils.md](references/platform-utils.md) |
+| Command prerequisites, `requires` field | [references/command-schema.md](references/command-schema.md) |
 | Surface validation, semantic quality | [references/surface-validation.md](references/surface-validation.md) |
 
 ## Core Principles

--- a/.claude/skills/afd/references/command-schema.md
+++ b/.claude/skills/afd/references/command-schema.md
@@ -115,6 +115,26 @@ defineCommand({
 | **Risk** | `destructive`, `safe` | Agent safety hints |
 | **Access** | `bootstrap`, `admin`, `public` | Permission filtering |
 
+## Command Prerequisites
+
+Commands can declare planning-order dependencies via the `requires` field. This is metadata only — not enforced at runtime — and helps agents reason about execution order.
+
+```typescript
+defineCommand({
+  name: 'order-create',
+  description: 'Creates a new order for the authenticated user',
+  requires: ['auth-sign-in'],  // Agent should call auth-sign-in first
+  mutation: true,
+  input: z.object({ items: z.array(z.string()) }),
+  async handler(input) { /* ... */ },
+});
+```
+
+**Key rules:**
+- `requires` entries must reference commands registered in the same surface (validated by `unresolved-prerequisite` rule)
+- No circular dependencies allowed (validated by `circular-prerequisite` rule)
+- Prerequisites are exposed via MCP tool `_meta.requires` and `afd-help` full format
+
 ## Design Principles
 
 ### 1. Return Data for the UI You Want

--- a/.claude/skills/afd/references/mcp-integration.md
+++ b/.claude/skills/afd/references/mcp-integration.md
@@ -328,6 +328,24 @@ export class AppRoot extends FASTElement {
 }
 ```
 
+## Tool Metadata (`_meta`)
+
+When commands have `requires` or `mutation` set, the MCP `tools/list` response includes a `_meta` object on each tool:
+
+```json
+{
+  "name": "order-create",
+  "description": "Creates a new order",
+  "inputSchema": { "type": "object", "properties": { ... } },
+  "_meta": {
+    "requires": ["auth-sign-in"],
+    "mutation": true
+  }
+}
+```
+
+`_meta` is only emitted when there is content (no empty objects). Agents can read `_meta.requires` to plan command execution order without trial-and-error.
+
 ## Environment Variables
 
 | Variable | Default | Description |

--- a/.claude/skills/afd/references/surface-validation.md
+++ b/.claude/skills/afd/references/surface-validation.md
@@ -59,7 +59,7 @@ interface SurfaceFinding {
 }
 ```
 
-## 9 Validation Rules
+## 11 Validation Rules
 
 ### 1. Similar Descriptions (`similar-descriptions`)
 **Severity:** Warning
@@ -135,6 +135,30 @@ import { computeComplexity } from '@lushly-dev/afd-testing';
 
 const result = computeComplexity(jsonSchema);
 // { score: 15, tier: 'high', breakdown: { fields: 6, depth: 1, unions: 1, ... } }
+```
+
+### 10. Unresolved Prerequisite (`unresolved-prerequisite`)
+**Severity:** Error
+
+Flags `requires` entries that reference commands not present in the validated command set. Catches typos and stale references.
+
+```typescript
+// This would trigger if "auth-sign-in" is not registered:
+defineCommand({
+  name: 'order-create',
+  requires: ['auth-sign-in'],  // error if auth-sign-in not in surface
+  // ...
+});
+```
+
+### 11. Circular Prerequisite (`circular-prerequisite`)
+**Severity:** Error
+
+Detects cycles in the `requires` dependency graph using DFS. A cycle means no valid execution order exists.
+
+```typescript
+// A → B → C → A would trigger:
+// "Circular prerequisite chain: A → B → C → A"
 ```
 
 ## Suppression System

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Zero React dependency on main entrypoint; React only pulled in via `/react` sub-path
   - All peer dependencies optional (`@lushly-dev/afd-server`, `zod`, `react`, `@convex-dev/auth`, `better-auth`)
 
+- **Command prerequisites** (`@lushly-dev/afd-core`, `@lushly-dev/afd-server`, `@lushly-dev/afd-testing`) — Declare planning-order dependencies between commands via `requires?: string[]` so agents can reason about command ordering without trial-and-error
+  - `CommandDefinition.requires` field in `@lushly-dev/afd-core` — metadata only, not enforced at runtime
+  - `defineCommand({ requires: ['auth-sign-in'] })` in `@lushly-dev/afd-server` — threaded through `ZodCommandOptions`, `ZodCommandDefinition`, `defineCommand()`, and `toCommandDefinition()`
+  - MCP tool `_meta` — individual tool listings now emit `_meta.requires` and `_meta.mutation` when present, giving agents prerequisite info at discovery time
+  - `afd-help` full format — `requires` array included in help output
+  - 2 new surface validation rules in `@lushly-dev/afd-testing`:
+    - `unresolved-prerequisite` (error) — flags `requires` entries referencing commands not in the surface
+    - `circular-prerequisite` (error) — detects cycles in the `requires` dependency graph via DFS
+  - 11 new tests (8 unit + 3 integration) covering both rules
+
 - **Surface validation (semantic quality analysis)** (`@lushly-dev/afd-testing`) — Cross-command analysis that detects semantic collisions, naming ambiguities, schema overlaps, and prompt injection risks. New `validateCommandSurface()` function with 8 rules:
   - `similar-descriptions` — Cosine similarity detection for command descriptions (configurable threshold)
   - `schema-overlap` — Shared input field detection between command pairs
@@ -63,9 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | Package | Tests | Status |
 |---------|-------|--------|
 | @lushly-dev/afd-core | 283 | Pass |
-| @lushly-dev/afd-server | 135 | Pass |
+| @lushly-dev/afd-server | 137 | Pass |
 | @lushly-dev/afd-client | 97 | Pass |
-| @lushly-dev/afd-testing | 169 | Pass |
+| @lushly-dev/afd-testing | 232 | Pass |
 | @lushly-dev/afd-adapters | 29 | Pass |
 | @lushly-dev/afd-cli | 14 | Pass |
 | **@lushly-dev/afd-auth** | **57** | **Pass** |

--- a/packages/core/src/commands.ts
+++ b/packages/core/src/commands.ts
@@ -197,6 +197,9 @@ export interface CommandDefinition<TInput = unknown, TOutput = unknown> {
 	 */
 	tags?: string[];
 
+	/** Commands that should be called before this one. Metadata only — not enforced at runtime. */
+	requires?: string[];
+
 	/**
 	 * Whether this command performs side effects.
 	 */

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -358,6 +358,7 @@ Create a command definition with Zod schema.
 | `mutation` | boolean | No | Whether command has side effects |
 | `version` | string | No | Command version |
 | `tags` | string[] | No | Additional tags |
+| `requires` | string[] | No | Commands that should be called before this one (metadata only) |
 | `errors` | string[] | No | Possible error codes |
 
 ### createMcpServer(options)

--- a/packages/server/src/bootstrap/afd-help.ts
+++ b/packages/server/src/bootstrap/afd-help.ts
@@ -21,6 +21,7 @@ interface CommandInfo {
 	category?: string;
 	tags?: string[];
 	mutation?: boolean;
+	requires?: string[];
 }
 
 interface HelpOutput {
@@ -78,6 +79,7 @@ export function createAfdHelpCommand(
 					info.category = cmd.category;
 					info.tags = cmd.tags;
 					info.mutation = cmd.mutation;
+					info.requires = cmd.requires;
 				}
 
 				return info;

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -48,6 +48,9 @@ export interface ZodCommandOptions<TInput extends ZodType<unknown, ZodTypeDef, u
 	/** Tags for additional categorization */
 	tags?: string[];
 
+	/** Commands that should be called before this one. Metadata only — not enforced at runtime. */
+	requires?: string[];
+
 	/** Estimated execution time category */
 	executionTime?: 'instant' | 'fast' | 'slow' | 'long-running';
 
@@ -114,6 +117,9 @@ export interface ZodCommandDefinition<
 
 	/** Tags for categorization */
 	tags?: string[];
+
+	/** Commands that should be called before this one. Metadata only — not enforced at runtime. */
+	requires?: string[];
 
 	/** Execution time category */
 	executionTime?: 'instant' | 'fast' | 'slow' | 'long-running';
@@ -190,6 +196,7 @@ export function defineCommand<TInput extends ZodType<unknown, ZodTypeDef, unknow
 		mutation: options.mutation,
 		version: options.version,
 		tags,
+		requires: options.requires,
 		executionTime: options.executionTime,
 		errors: options.errors,
 		handoff: options.handoff,
@@ -205,6 +212,7 @@ export function defineCommand<TInput extends ZodType<unknown, ZodTypeDef, unknow
 				mutation: options.mutation,
 				version: options.version,
 				tags,
+				requires: options.requires,
 				executionTime: options.executionTime,
 				errors: options.errors,
 				handoff: options.handoff,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -832,6 +832,7 @@ export function createMcpServer(options: McpServerOptions): McpServer {
 				pipeTool,
 				...commands.map((cmd) => {
 					const { type: _type, ...restSchema } = cmd.jsonSchema;
+					const hasMeta = (cmd.requires && cmd.requires.length > 0) || cmd.mutation != null;
 					return {
 						name: cmd.name,
 						description: cmd.description,
@@ -839,6 +840,12 @@ export function createMcpServer(options: McpServerOptions): McpServer {
 							type: 'object' as const,
 							...restSchema,
 						},
+						...(hasMeta && {
+							_meta: {
+								...(cmd.requires?.length && { requires: cmd.requires }),
+								...(cmd.mutation != null && { mutation: cmd.mutation }),
+							},
+						}),
 					};
 				}),
 			];

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -62,6 +62,8 @@ console.log(result.findings);       // SurfaceFinding[] with rule, severity, mes
 | `description-quality` | Warning | Descriptions that are too short or missing action verbs |
 | `orphaned-category` | Info | Categories containing only one command |
 | `schema-complexity` | Warning/Info | Input schemas too complex for agents (unions, nesting, constraints) |
+| `unresolved-prerequisite` | Error | `requires` entry references a command not in the surface |
+| `circular-prerequisite` | Error | Circular dependency cycle in the `requires` graph |
 
 ### Options
 
@@ -1047,6 +1049,8 @@ const result = await registry.execute('document-create', { title: 'New Doc' });
 | `description-quality` | Warning | Description too short or missing action verb |
 | `orphaned-category` | Info | Category contains only one command |
 | `schema-complexity` | Warning/Info | Input schema too complex for agents (scored by fields, depth, unions, constraints) |
+| `unresolved-prerequisite` | Error | `requires` entry references a command not in the surface |
+| `circular-prerequisite` | Error | Circular dependency cycle in the `requires` graph |
 
 ## License
 

--- a/packages/testing/src/surface/index.ts
+++ b/packages/testing/src/surface/index.ts
@@ -9,6 +9,7 @@
 export { checkInjection, INJECTION_PATTERNS } from './injection.js';
 // Rules (for direct use / testing)
 export {
+	checkCircularPrerequisites,
 	checkDescriptionInjection,
 	checkDescriptionQuality,
 	checkMissingCategory,
@@ -18,6 +19,7 @@ export {
 	checkSchemaComplexity,
 	checkSchemaOverlap,
 	checkSimilarDescriptions,
+	checkUnresolvedPrerequisites,
 	DESCRIPTION_VERBS,
 } from './rules.js';
 

--- a/packages/testing/src/surface/types.ts
+++ b/packages/testing/src/surface/types.ts
@@ -133,7 +133,9 @@ export type SurfaceRule =
 	| 'description-injection'
 	| 'description-quality'
 	| 'orphaned-category'
-	| 'schema-complexity';
+	| 'schema-complexity'
+	| 'unresolved-prerequisite'
+	| 'circular-prerequisite';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // INJECTION TYPES
@@ -311,4 +313,5 @@ export interface SurfaceCommand {
 	description: string;
 	category?: string;
 	jsonSchema?: JsonSchema;
+	requires?: string[];
 }


### PR DESCRIPTION
## Summary

- Add `requires?: string[]` field to `CommandDefinition` so commands can declare planning-order dependencies (e.g., `auth-sign-in` before `order-create`). Metadata only — not enforced at runtime.
- Thread `requires` through `ZodCommandOptions`, `defineCommand()`, `toCommandDefinition()`, MCP tool `_meta`, and `afd-help` full format output
- Add two new surface validation rules: `unresolved-prerequisite` (flags references to missing commands) and `circular-prerequisite` (DFS cycle detection)
- 11 new tests (8 unit + 3 integration), all passing
- Update CHANGELOG, package READMEs, and skill references

## Changes

| Package | Change |
|---------|--------|
| `@lushly-dev/afd-core` | `requires?: string[]` on `CommandDefinition` |
| `@lushly-dev/afd-server` | `requires` in schema, `_meta` on MCP tools, help output |
| `@lushly-dev/afd-testing` | 2 new surface validation rules + 11 tests |
| Docs/skills | CHANGELOG, READMEs, skill references updated |

## Test plan

- [x] `pnpm build` — all packages compile
- [x] `pnpm test` — full suite green (232 testing, 137 server, all others unchanged)
- [x] `pnpm typecheck` — no type errors
- [x] Unit tests cover: valid requires, missing prerequisite, multiple missing, no requires field, no cycle, direct cycle, multi-hop cycle, self-reference
- [x] Integration tests cover: validateCommandSurface detects unresolved, circular, and passes valid requires

🤖 Generated with [Claude Code](https://claude.com/claude-code)