### PR TITLE
test: add 246 tests to close coverage gaps across 4 packages

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,0 +1,146 @@
+import type { McpRequest, McpResponse } from '@lushly-dev/afd-core';
+import { describe, expect, it, vi } from 'vitest';
+import { McpClient } from './client.js';
+import type { Transport } from './transport.js';
+
+/**
+ * Create a mock transport for testing McpClient without network.
+ */
+function _createMockTransport(overrides?: Partial<Transport>): Transport & {
+	messageHandler: ((response: McpResponse) => void) | null;
+	errorHandler: ((error: Error) => void) | null;
+	closeHandler: (() => void) | null;
+	sendMock: ReturnType<typeof vi.fn>;
+} {
+	let messageHandler: ((response: McpResponse) => void) | null = null;
+	let errorHandler: ((error: Error) => void) | null = null;
+	let closeHandler: (() => void) | null = null;
+	let connected = false;
+
+	const sendMock = vi.fn<(req: McpRequest) => Promise<McpResponse>>();
+
+	const transport: Transport = {
+		connect: vi.fn(async () => {
+			connected = true;
+		}),
+		disconnect: vi.fn(() => {
+			connected = false;
+		}),
+		send: sendMock,
+		isConnected: () => connected,
+		onMessage: (handler) => {
+			messageHandler = handler;
+		},
+		onError: (handler) => {
+			errorHandler = handler;
+		},
+		onClose: (handler) => {
+			closeHandler = handler;
+		},
+		...overrides,
+	};
+
+	return Object.assign(transport, { messageHandler, errorHandler, closeHandler, sendMock });
+}
+
+describe('McpClient - constructor', () => {
+	it('throws without url or endpoint', () => {
+		expect(() => new McpClient({})).toThrow('Either url or endpoint must be provided');
+	});
+
+	it('accepts url', () => {
+		const client = new McpClient({ url: 'http://localhost:3100/sse' });
+		expect(client.getStatus().state).toBe('disconnected');
+	});
+
+	it('accepts endpoint as url alias', () => {
+		const client = new McpClient({ endpoint: 'http://localhost:3100/message' });
+		expect(client.getStatus().state).toBe('disconnected');
+	});
+});
+
+describe('McpClient - status', () => {
+	it('initial status is disconnected', () => {
+		const client = new McpClient({ url: 'http://localhost:3100/sse' });
+		const status = client.getStatus();
+		expect(status.state).toBe('disconnected');
+		expect(status.url).toBeNull();
+		expect(status.serverInfo).toBeNull();
+		expect(status.capabilities).toBeNull();
+		expect(status.connectedAt).toBeNull();
+		expect(status.reconnectAttempts).toBe(0);
+		expect(status.pendingRequests).toBe(0);
+	});
+
+	it('isConnected returns false when disconnected', () => {
+		const client = new McpClient({ url: 'http://localhost:3100/sse' });
+		expect(client.isConnected()).toBe(false);
+	});
+});
+
+describe('McpClient - events', () => {
+	it('on/off subscribe and unsubscribe', () => {
+		const client = new McpClient({ url: 'http://localhost:3100/sse' });
+		const handler = vi.fn();
+		const unsubscribe = client.on('error', handler);
+
+		// Unsubscribe
+		unsubscribe();
+		// After unsubscribe, handler should not be called
+		// (we can't trigger events without connecting, but verify the API works)
+		expect(typeof unsubscribe).toBe('function');
+	});
+});
+
+describe('McpClient - call', () => {
+	it('returns failure when callTool throws', async () => {
+		const client = new McpClient({ url: 'http://localhost:3100/sse' });
+		// request() will throw "Not connected"
+		const result = await client.call('test-cmd', { a: 1 });
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('McpClient - batch', () => {
+	it('returns failed batch when callTool throws', async () => {
+		const client = new McpClient({ url: 'http://localhost:3100/sse' });
+		const result = await client.batch([{ command: 'test-cmd', input: { a: 1 } }]);
+		expect(result.success).toBe(false);
+		expect(result.summary.failureCount).toBe(1);
+		expect(result.error?.code).toBe('BATCH_ERROR');
+	});
+});
+
+describe('McpClient - pipe', () => {
+	it('normalizes array steps to PipelineRequest', async () => {
+		const client = new McpClient({ url: 'http://localhost:3100/sse' });
+		const result = await client.pipe([{ command: 'user-get', input: { id: 1 }, as: 'user' }]);
+		// Not connected, so it catches and returns error pipeline result
+		expect(result.metadata.confidence).toBe(0);
+		expect(result.steps).toHaveLength(1);
+		expect(result.steps[0]?.command).toBe('user-get');
+	});
+
+	it('accepts full PipelineRequest object', async () => {
+		const client = new McpClient({ url: 'http://localhost:3100/sse' });
+		const result = await client.pipe({
+			steps: [{ command: 'test-cmd', input: {} }],
+		});
+		expect(result.metadata.totalSteps).toBe(1);
+	});
+});
+
+describe('McpClient - disconnect', () => {
+	it('can disconnect even when not connected', async () => {
+		const client = new McpClient({ url: 'http://localhost:3100/sse' });
+		await client.disconnect();
+		expect(client.getStatus().state).toBe('disconnected');
+	});
+});
+
+describe('McpClient - getTools', () => {
+	it('returns empty array initially', () => {
+		const client = new McpClient({ url: 'http://localhost:3100/sse' });
+		expect(client.getTools()).toEqual([]);
+	});
+});

--- a/packages/client/src/transport.test.ts
+++ b/packages/client/src/transport.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTransport, HttpTransport, SseTransport } from './transport.js';
+
+describe('createTransport', () => {
+	it('creates SseTransport for "sse" type', () => {
+		const transport = createTransport('sse', 'http://localhost:3100/sse');
+		expect(transport).toBeInstanceOf(SseTransport);
+	});
+
+	it('creates HttpTransport for "http" type', () => {
+		const transport = createTransport('http', 'http://localhost:3100/message');
+		expect(transport).toBeInstanceOf(HttpTransport);
+	});
+
+	it('throws for unsupported transport type', () => {
+		expect(() => createTransport('websocket' as 'sse', 'ws://localhost:3100')).toThrow(
+			'Unsupported transport type: websocket'
+		);
+	});
+});
+
+describe('SseTransport', () => {
+	it('derives message endpoint from SSE URL', () => {
+		const transport = new SseTransport('http://localhost:3100/sse');
+		// Verify by checking the transport was created without error
+		expect(transport).toBeInstanceOf(SseTransport);
+	});
+
+	it('handles URL with trailing slash', () => {
+		const transport = new SseTransport('http://localhost:3100/sse/');
+		expect(transport).toBeInstanceOf(SseTransport);
+	});
+
+	it('isConnected returns false initially', () => {
+		const transport = new SseTransport('http://localhost:3100/sse');
+		expect(transport.isConnected()).toBe(false);
+	});
+
+	it('disconnect when not connected does nothing', () => {
+		const transport = new SseTransport('http://localhost:3100/sse');
+		transport.disconnect();
+		expect(transport.isConnected()).toBe(false);
+	});
+
+	it('accepts handler registrations', () => {
+		const transport = new SseTransport('http://localhost:3100/sse');
+		transport.onMessage(vi.fn());
+		transport.onError(vi.fn());
+		transport.onClose(vi.fn());
+		// No error thrown
+	});
+});
+
+describe('HttpTransport', () => {
+	it('converts /sse URL to /message', () => {
+		const transport = new HttpTransport('http://localhost:3100/sse');
+		expect(transport.url).toBe('http://localhost:3100/sse');
+	});
+
+	it('keeps /message URL as-is', () => {
+		const transport = new HttpTransport('http://localhost:3100/message');
+		expect(transport.url).toBe('http://localhost:3100/message');
+	});
+
+	it('keeps non-standard URL as-is', () => {
+		const transport = new HttpTransport('http://localhost:3100/api');
+		expect(transport.url).toBe('http://localhost:3100/api');
+	});
+
+	it('isConnected returns false initially', () => {
+		const transport = new HttpTransport('http://localhost:3100/message');
+		expect(transport.isConnected()).toBe(false);
+	});
+
+	it('disconnect sets connected to false and calls close handler', () => {
+		const transport = new HttpTransport('http://localhost:3100/message');
+		const closeHandler = vi.fn();
+		transport.onClose(closeHandler);
+
+		// Manually set connected state through connect
+		// We can't easily mock fetch here, so just test disconnect behavior
+		transport.disconnect();
+		expect(transport.isConnected()).toBe(false);
+		expect(closeHandler).toHaveBeenCalled();
+	});
+
+	it('onMessage stores handler', () => {
+		const transport = new HttpTransport('http://localhost:3100/message');
+		const handler = vi.fn();
+		transport.onMessage(handler);
+		// No error thrown
+	});
+
+	it('onError is no-op (errors propagate via thrown exceptions)', () => {
+		const transport = new HttpTransport('http://localhost:3100/message');
+		transport.onError(vi.fn());
+		// No error thrown
+	});
+
+	it('connect marks as connected (fallback path)', async () => {
+		// Mock fetch to simulate failed health check
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+		try {
+			const transport = new HttpTransport('http://localhost:3100/message');
+			await transport.connect();
+			// Fallback: marks as connected even if health check fails
+			expect(transport.isConnected()).toBe(true);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it('connect marks as connected on successful health check', async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = vi.fn().mockResolvedValue({ ok: true });
+
+		try {
+			const transport = new HttpTransport('http://localhost:3100/message');
+			await transport.connect();
+			expect(transport.isConnected()).toBe(true);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it('send throws on non-ok response', async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 500,
+			statusText: 'Internal Server Error',
+		});
+
+		try {
+			const transport = new HttpTransport('http://localhost:3100/message');
+			await expect(transport.send({ jsonrpc: '2.0', id: 1, method: 'test' })).rejects.toThrow(
+				'HTTP error: 500 Internal Server Error'
+			);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it('send throws on invalid MCP response', async () => {
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ not: 'an mcp response' }),
+		});
+
+		try {
+			const transport = new HttpTransport('http://localhost:3100/message');
+			await expect(transport.send({ jsonrpc: '2.0', id: 1, method: 'test' })).rejects.toThrow(
+				'Invalid MCP response received'
+			);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it('send returns valid MCP response and dispatches to message handler', async () => {
+		const validResponse = { jsonrpc: '2.0', id: 1, result: { tools: [] } };
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => validResponse,
+		});
+
+		try {
+			const transport = new HttpTransport('http://localhost:3100/message');
+			const messageHandler = vi.fn();
+			transport.onMessage(messageHandler);
+
+			const response = await transport.send({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+			expect(response.result).toEqual({ tools: [] });
+			expect(messageHandler).toHaveBeenCalledWith(validResponse);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});

--- a/packages/core/src/commands.test.ts
+++ b/packages/core/src/commands.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from 'vitest';
 import {
 	type CommandDefinition,
 	commandsToMcpTools,
+	commandToMcpTool,
 	createCommandRegistry,
 	defaultExpose,
 	isMcpExposed,
 	validateCommandName,
 } from './commands.js';
-import { success } from './result.js';
+import { failure, success } from './result.js';
 
 describe('createCommandRegistry', () => {
 	describe('listByTags', () => {
@@ -458,5 +459,436 @@ describe('defaultExpose', () => {
 
 	it('is frozen', () => {
 		expect(Object.isFrozen(defaultExpose)).toBe(true);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// NEW TESTS: Registry CRUD, execute error paths, batch, stream, commandToMcpTool
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('createCommandRegistry - register', () => {
+	it('throws on duplicate registration', () => {
+		const registry = createCommandRegistry();
+		const cmd: CommandDefinition = {
+			name: 'dup-cmd',
+			description: 'First',
+			parameters: [],
+			handler: async () => success(null),
+		};
+		registry.register(cmd);
+		expect(() => registry.register(cmd)).toThrow("Command 'dup-cmd' is already registered");
+	});
+});
+
+describe('createCommandRegistry - get/has/list/listByCategory', () => {
+	it('get returns command by name', () => {
+		const registry = createCommandRegistry();
+		const cmd: CommandDefinition = {
+			name: 'my-cmd',
+			description: 'test',
+			parameters: [],
+			handler: async () => success(null),
+		};
+		registry.register(cmd);
+		expect(registry.get('my-cmd')).toBe(cmd);
+	});
+
+	it('get returns undefined for unknown command', () => {
+		const registry = createCommandRegistry();
+		expect(registry.get('nonexistent-cmd')).toBeUndefined();
+	});
+
+	it('has returns true for registered commands', () => {
+		const registry = createCommandRegistry();
+		const cmd: CommandDefinition = {
+			name: 'exists-cmd',
+			description: 'test',
+			parameters: [],
+			handler: async () => success(null),
+		};
+		registry.register(cmd);
+		expect(registry.has('exists-cmd')).toBe(true);
+		expect(registry.has('nope-cmd')).toBe(false);
+	});
+
+	it('list returns all registered commands', () => {
+		const registry = createCommandRegistry();
+		const cmd1: CommandDefinition = {
+			name: 'cmd-one',
+			description: 'one',
+			parameters: [],
+			handler: async () => success(null),
+		};
+		const cmd2: CommandDefinition = {
+			name: 'cmd-two',
+			description: 'two',
+			parameters: [],
+			handler: async () => success(null),
+		};
+		registry.register(cmd1);
+		registry.register(cmd2);
+		expect(registry.list()).toHaveLength(2);
+	});
+
+	it('listByCategory filters by category', () => {
+		const registry = createCommandRegistry();
+		const cmd1: CommandDefinition = {
+			name: 'cat-one',
+			description: 'one',
+			category: 'alpha',
+			parameters: [],
+			handler: async () => success(null),
+		};
+		const cmd2: CommandDefinition = {
+			name: 'cat-two',
+			description: 'two',
+			category: 'beta',
+			parameters: [],
+			handler: async () => success(null),
+		};
+		registry.register(cmd1);
+		registry.register(cmd2);
+		expect(registry.listByCategory('alpha')).toHaveLength(1);
+		expect(registry.listByCategory('alpha')[0]?.name).toBe('cat-one');
+		expect(registry.listByCategory('gamma')).toHaveLength(0);
+	});
+});
+
+describe('createCommandRegistry - execute error paths', () => {
+	it('returns COMMAND_NOT_FOUND for missing command', async () => {
+		const registry = createCommandRegistry();
+		const result = await registry.execute('not-found', {});
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('COMMAND_NOT_FOUND');
+	});
+
+	it('catches handler exceptions and returns COMMAND_EXECUTION_ERROR', async () => {
+		const registry = createCommandRegistry();
+		const cmd: CommandDefinition = {
+			name: 'throw-cmd',
+			description: 'throws',
+			parameters: [],
+			handler: async () => {
+				throw new Error('handler exploded');
+			},
+		};
+		registry.register(cmd);
+		const result = await registry.execute('throw-cmd', {});
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('COMMAND_EXECUTION_ERROR');
+		expect(result.error?.message).toContain('handler exploded');
+	});
+
+	it('catches non-Error throws', async () => {
+		const registry = createCommandRegistry();
+		const cmd: CommandDefinition = {
+			name: 'throw-string',
+			description: 'throws string',
+			parameters: [],
+			handler: async () => {
+				throw 'string error';
+			},
+		};
+		registry.register(cmd);
+		const result = await registry.execute('throw-string', {});
+		expect(result.success).toBe(false);
+		expect(result.error?.message).toBe('string error');
+	});
+});
+
+describe('createCommandRegistry - executeBatch', () => {
+	function makeRegistry() {
+		const registry = createCommandRegistry();
+		registry.register({
+			name: 'pass-cmd',
+			description: 'passes',
+			parameters: [],
+			handler: async (input) => success(input),
+		});
+		registry.register({
+			name: 'fail-cmd',
+			description: 'fails',
+			parameters: [],
+			handler: async () => failure({ code: 'FAIL', message: 'intentional' }),
+		});
+		return registry;
+	}
+
+	it('rejects empty batch', async () => {
+		const registry = makeRegistry();
+		const result = await registry.executeBatch({ commands: [] });
+		expect(result.success).toBe(false);
+		expect(result.error?.code).toBe('INVALID_BATCH_REQUEST');
+	});
+
+	it('executes sequential batch successfully', async () => {
+		const registry = makeRegistry();
+		const result = await registry.executeBatch({
+			commands: [
+				{ command: 'pass-cmd', input: { a: 1 } },
+				{ command: 'pass-cmd', input: { b: 2 } },
+			],
+		});
+		expect(result.success).toBe(true);
+		expect(result.results).toHaveLength(2);
+		expect(result.summary.successCount).toBe(2);
+		expect(result.timing.totalMs).toBeGreaterThanOrEqual(0);
+	});
+
+	it('stopOnError skips remaining commands', async () => {
+		const registry = makeRegistry();
+		const result = await registry.executeBatch({
+			commands: [
+				{ command: 'fail-cmd', input: {} },
+				{ command: 'pass-cmd', input: {} },
+			],
+			options: { stopOnError: true },
+		});
+		expect(result.results).toHaveLength(2);
+		expect(result.results[0]?.result.success).toBe(false);
+		expect(result.results[1]?.result.error?.code).toBe('COMMAND_SKIPPED');
+	});
+
+	it('uses custom IDs when provided', async () => {
+		const registry = makeRegistry();
+		const result = await registry.executeBatch({
+			commands: [{ id: 'custom-1', command: 'pass-cmd', input: {} }],
+		});
+		expect(result.results[0]?.id).toBe('custom-1');
+	});
+
+	it('generates default IDs when not provided', async () => {
+		const registry = makeRegistry();
+		const result = await registry.executeBatch({
+			commands: [{ command: 'pass-cmd', input: {} }],
+		});
+		expect(result.results[0]?.id).toBe('cmd-0');
+	});
+
+	it('executes parallel batch', async () => {
+		const registry = makeRegistry();
+		const result = await registry.executeBatch({
+			commands: [
+				{ command: 'pass-cmd', input: { a: 1 } },
+				{ command: 'pass-cmd', input: { b: 2 } },
+				{ command: 'pass-cmd', input: { c: 3 } },
+			],
+			options: { parallelism: 2 },
+		});
+		expect(result.success).toBe(true);
+		expect(result.results).toHaveLength(3);
+		expect(result.summary.successCount).toBe(3);
+	});
+
+	it('parallel batch stopOnError skips remaining', async () => {
+		const registry = makeRegistry();
+		const result = await registry.executeBatch({
+			commands: [
+				{ command: 'fail-cmd', input: {} },
+				{ command: 'pass-cmd', input: {} },
+				{ command: 'pass-cmd', input: {} },
+				{ command: 'pass-cmd', input: {} },
+			],
+			options: { parallelism: 2, stopOnError: true },
+		});
+		// First batch of 2 runs (fail + pass), then remaining skipped
+		const skipped = result.results.filter((r) => r.result.error?.code === 'COMMAND_SKIPPED');
+		expect(skipped.length).toBe(2);
+	});
+
+	it('timeout skips remaining commands', async () => {
+		const registry = createCommandRegistry();
+		registry.register({
+			name: 'slow-cmd',
+			description: 'slow',
+			parameters: [],
+			handler: async () => {
+				await new Promise((r) => setTimeout(r, 50));
+				return success('done');
+			},
+		});
+		const result = await registry.executeBatch({
+			commands: [
+				{ command: 'slow-cmd', input: {} },
+				{ command: 'slow-cmd', input: {} },
+				{ command: 'slow-cmd', input: {} },
+			],
+			options: { timeout: 10 },
+		});
+		const timeouts = result.results.filter((r) => r.result.error?.code === 'BATCH_TIMEOUT');
+		expect(timeouts.length).toBeGreaterThan(0);
+	});
+});
+
+describe('createCommandRegistry - executeStream', () => {
+	it('streams single result as one data chunk + complete', async () => {
+		const registry = createCommandRegistry();
+		registry.register({
+			name: 'single-cmd',
+			description: 'single',
+			parameters: [],
+			handler: async () => success({ value: 42 }),
+		});
+
+		const chunks = [];
+		for await (const chunk of registry.executeStream('single-cmd', {})) {
+			chunks.push(chunk);
+		}
+		expect(chunks).toHaveLength(2);
+		expect(chunks[0]?.type).toBe('data');
+		expect(chunks[1]?.type).toBe('complete');
+	});
+
+	it('streams array results as multiple data chunks', async () => {
+		const registry = createCommandRegistry();
+		registry.register({
+			name: 'array-cmd',
+			description: 'array',
+			parameters: [],
+			handler: async () => success([1, 2, 3]),
+		});
+
+		const chunks = [];
+		for await (const chunk of registry.executeStream('array-cmd', {})) {
+			chunks.push(chunk);
+		}
+		// 3 data chunks + 1 complete
+		expect(chunks).toHaveLength(4);
+		expect(chunks[0]?.type).toBe('data');
+		expect(chunks[1]?.type).toBe('data');
+		expect(chunks[2]?.type).toBe('data');
+		expect(chunks[3]?.type).toBe('complete');
+	});
+
+	it('emits error chunk for missing command', async () => {
+		const registry = createCommandRegistry();
+		const chunks = [];
+		for await (const chunk of registry.executeStream('missing-cmd', {})) {
+			chunks.push(chunk);
+		}
+		expect(chunks).toHaveLength(1);
+		expect(chunks[0]?.type).toBe('error');
+	});
+
+	it('emits error chunk when already aborted', async () => {
+		const registry = createCommandRegistry();
+		registry.register({
+			name: 'abort-test',
+			description: 'test',
+			parameters: [],
+			handler: async () => success('ok'),
+		});
+
+		const controller = new AbortController();
+		controller.abort();
+
+		const chunks = [];
+		for await (const chunk of registry.executeStream(
+			'abort-test',
+			{},
+			{
+				signal: controller.signal,
+			}
+		)) {
+			chunks.push(chunk);
+		}
+		expect(chunks).toHaveLength(1);
+		expect(chunks[0]?.type).toBe('error');
+		if (chunks[0]?.type === 'error') {
+			expect(chunks[0].error.code).toBe('STREAM_ABORTED');
+		}
+	});
+
+	it('emits error chunk for handler exceptions', async () => {
+		const registry = createCommandRegistry();
+		registry.register({
+			name: 'throw-stream',
+			description: 'throws',
+			parameters: [],
+			handler: async () => {
+				throw new Error('stream error');
+			},
+		});
+
+		const chunks = [];
+		for await (const chunk of registry.executeStream('throw-stream', {})) {
+			chunks.push(chunk);
+		}
+		// The execute method catches the error, so it comes back as command error,
+		// then stream emits error chunk
+		expect(chunks).toHaveLength(1);
+		expect(chunks[0]?.type).toBe('error');
+	});
+});
+
+describe('commandToMcpTool', () => {
+	it('converts parameters to inputSchema', () => {
+		const cmd: CommandDefinition = {
+			name: 'test-tool',
+			description: 'A test tool',
+			parameters: [
+				{ name: 'title', type: 'string', description: 'The title', required: true },
+				{ name: 'count', type: 'number', description: 'A count', required: false },
+			],
+			handler: async () => success(null),
+		};
+
+		const tool = commandToMcpTool(cmd);
+		expect(tool.name).toBe('test-tool');
+		expect(tool.description).toBe('A test tool');
+		expect(tool.inputSchema.type).toBe('object');
+		expect(tool.inputSchema.required).toEqual(['title']);
+		expect(tool.inputSchema.properties.title).toEqual({
+			type: 'string',
+			description: 'The title',
+		});
+		expect(tool.inputSchema.properties.count).toEqual({
+			type: 'number',
+			description: 'A count',
+		});
+	});
+
+	it('uses custom schema when provided', () => {
+		const customSchema = { type: 'string' as const, description: 'custom', minLength: 1 };
+		const cmd: CommandDefinition = {
+			name: 'custom-schema',
+			description: 'test',
+			parameters: [
+				{
+					name: 'input',
+					type: 'string',
+					description: 'Input',
+					required: true,
+					schema: customSchema,
+				},
+			],
+			handler: async () => success(null),
+		};
+
+		const tool = commandToMcpTool(cmd);
+		expect(tool.inputSchema.properties.input).toBe(customSchema);
+	});
+
+	it('includes default and enum in schema', () => {
+		const cmd: CommandDefinition = {
+			name: 'enum-cmd',
+			description: 'test',
+			parameters: [
+				{
+					name: 'format',
+					type: 'string',
+					description: 'Output format',
+					required: false,
+					default: 'json',
+					enum: ['json', 'csv'],
+				},
+			],
+			handler: async () => success(null),
+		};
+
+		const tool = commandToMcpTool(cmd);
+		const prop = tool.inputSchema.properties.format;
+		expect(prop.default).toBe('json');
+		expect(prop.enum).toEqual(['json', 'csv']);
 	});
 });

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import {
+	type CommandError,
+	createError,
+	ErrorCodes,
+	internalError,
+	isCommandError,
+	notFoundError,
+	rateLimitError,
+	timeoutError,
+	validationError,
+	wrapError,
+} from './errors.js';
+
+describe('createError', () => {
+	it('creates error with code and message', () => {
+		const err = createError('MY_CODE', 'something broke');
+		expect(err.code).toBe('MY_CODE');
+		expect(err.message).toBe('something broke');
+	});
+
+	it('merges optional fields', () => {
+		const err = createError('FOO', 'bar', {
+			suggestion: 'try again',
+			retryable: true,
+			details: { key: 'val' },
+		});
+		expect(err.suggestion).toBe('try again');
+		expect(err.retryable).toBe(true);
+		expect(err.details).toEqual({ key: 'val' });
+	});
+
+	it('returns plain object without extra properties when no options given', () => {
+		const err = createError('X', 'Y');
+		expect(Object.keys(err).sort()).toEqual(['code', 'message']);
+	});
+});
+
+describe('validationError', () => {
+	it('uses VALIDATION_ERROR code', () => {
+		const err = validationError('bad input');
+		expect(err.code).toBe(ErrorCodes.VALIDATION_ERROR);
+		expect(err.message).toBe('bad input');
+		expect(err.retryable).toBe(false);
+		expect(err.suggestion).toBeDefined();
+	});
+
+	it('includes details when provided', () => {
+		const err = validationError('missing field', { field: 'name' });
+		expect(err.details).toEqual({ field: 'name' });
+	});
+});
+
+describe('notFoundError', () => {
+	it('formats resource type and id in message', () => {
+		const err = notFoundError('User', '42');
+		expect(err.code).toBe(ErrorCodes.NOT_FOUND);
+		expect(err.message).toContain('User');
+		expect(err.message).toContain('42');
+		expect(err.retryable).toBe(false);
+		expect(err.details).toEqual({ resourceType: 'User', resourceId: '42' });
+	});
+
+	it('lowercases resource type in suggestion', () => {
+		const err = notFoundError('Document', 'abc');
+		expect(err.suggestion).toContain('document');
+	});
+});
+
+describe('rateLimitError', () => {
+	it('includes retry time when provided', () => {
+		const err = rateLimitError(60);
+		expect(err.code).toBe(ErrorCodes.RATE_LIMITED);
+		expect(err.suggestion).toContain('60');
+		expect(err.retryable).toBe(true);
+		expect(err.details).toEqual({ retryAfterSeconds: 60 });
+	});
+
+	it('uses generic suggestion without retry time', () => {
+		const err = rateLimitError();
+		expect(err.suggestion).toContain('Wait');
+		expect(err.details).toBeUndefined();
+	});
+});
+
+describe('timeoutError', () => {
+	it('includes operation name and timeout in message', () => {
+		const err = timeoutError('fetchData', 5000);
+		expect(err.code).toBe(ErrorCodes.TIMEOUT);
+		expect(err.message).toContain('fetchData');
+		expect(err.message).toContain('5000');
+		expect(err.retryable).toBe(true);
+		expect(err.details).toEqual({ operationName: 'fetchData', timeoutMs: 5000 });
+	});
+});
+
+describe('internalError', () => {
+	it('creates internal error with message', () => {
+		const err = internalError('something went wrong');
+		expect(err.code).toBe(ErrorCodes.INTERNAL_ERROR);
+		expect(err.message).toBe('something went wrong');
+		expect(err.retryable).toBe(true);
+	});
+
+	it('attaches cause when provided', () => {
+		const cause = new Error('root cause');
+		const err = internalError('wrapped', cause);
+		expect(err.cause).toBe(cause);
+	});
+});
+
+describe('wrapError', () => {
+	it('returns CommandError unchanged (idempotent)', () => {
+		const original: CommandError = {
+			code: 'CUSTOM',
+			message: 'already wrapped',
+			suggestion: 'do nothing',
+		};
+		const wrapped = wrapError(original);
+		expect(wrapped).toBe(original);
+	});
+
+	it('wraps Error instances', () => {
+		const err = new Error('native error');
+		const wrapped = wrapError(err);
+		expect(wrapped.code).toBe(ErrorCodes.INTERNAL_ERROR);
+		expect(wrapped.message).toBe('native error');
+		expect(wrapped.cause).toBe(err);
+		expect(wrapped.details?.stack).toBeDefined();
+	});
+
+	it('wraps non-Error values as strings', () => {
+		const wrapped = wrapError('string error');
+		expect(wrapped.code).toBe(ErrorCodes.UNKNOWN_ERROR);
+		expect(wrapped.message).toBe('string error');
+	});
+
+	it('wraps numbers as strings', () => {
+		const wrapped = wrapError(404);
+		expect(wrapped.message).toBe('404');
+	});
+
+	it('wraps null as string', () => {
+		const wrapped = wrapError(null);
+		expect(wrapped.message).toBe('null');
+	});
+});
+
+describe('isCommandError', () => {
+	it('returns true for valid CommandError objects', () => {
+		expect(isCommandError({ code: 'ERR', message: 'msg' })).toBe(true);
+	});
+
+	it('returns true for errors with extra fields', () => {
+		expect(
+			isCommandError({ code: 'ERR', message: 'msg', suggestion: 'try again', retryable: true })
+		).toBe(true);
+	});
+
+	it('returns false for null', () => {
+		expect(isCommandError(null)).toBe(false);
+	});
+
+	it('returns false for undefined', () => {
+		expect(isCommandError(undefined)).toBe(false);
+	});
+
+	it('returns false for primitives', () => {
+		expect(isCommandError('string')).toBe(false);
+		expect(isCommandError(42)).toBe(false);
+		expect(isCommandError(true)).toBe(false);
+	});
+
+	it('returns false for objects missing code', () => {
+		expect(isCommandError({ message: 'msg' })).toBe(false);
+	});
+
+	it('returns false for objects missing message', () => {
+		expect(isCommandError({ code: 'ERR' })).toBe(false);
+	});
+
+	it('returns false when code is not a string', () => {
+		expect(isCommandError({ code: 42, message: 'msg' })).toBe(false);
+	});
+
+	it('returns false when message is not a string', () => {
+		expect(isCommandError({ code: 'ERR', message: 42 })).toBe(false);
+	});
+});

--- a/packages/core/src/mcp.test.ts
+++ b/packages/core/src/mcp.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createMcpErrorResponse,
+	createMcpRequest,
+	createMcpResponse,
+	isMcpNotification,
+	isMcpRequest,
+	isMcpResponse,
+	textContent,
+} from './mcp.js';
+
+describe('createMcpRequest', () => {
+	it('creates request with auto-incrementing IDs', () => {
+		const req1 = createMcpRequest('tools/list');
+		const req2 = createMcpRequest('tools/call');
+		expect(req2.id).toBeGreaterThan(req1.id as number);
+	});
+
+	it('sets jsonrpc to 2.0', () => {
+		const req = createMcpRequest('test/method');
+		expect(req.jsonrpc).toBe('2.0');
+	});
+
+	it('sets method correctly', () => {
+		const req = createMcpRequest('tools/list');
+		expect(req.method).toBe('tools/list');
+	});
+
+	it('includes params when provided', () => {
+		const req = createMcpRequest('tools/call', { name: 'my-tool' });
+		expect(req.params).toEqual({ name: 'my-tool' });
+	});
+
+	it('omits params when not provided', () => {
+		const req = createMcpRequest('test');
+		expect(req.params).toBeUndefined();
+	});
+});
+
+describe('createMcpResponse', () => {
+	it('creates success response with result', () => {
+		const res = createMcpResponse(1, { data: 'hello' });
+		expect(res.jsonrpc).toBe('2.0');
+		expect(res.id).toBe(1);
+		expect(res.result).toEqual({ data: 'hello' });
+		expect(res.error).toBeUndefined();
+	});
+
+	it('accepts string IDs', () => {
+		const res = createMcpResponse('abc-123', null);
+		expect(res.id).toBe('abc-123');
+	});
+});
+
+describe('createMcpErrorResponse', () => {
+	it('creates error response with code and message', () => {
+		const res = createMcpErrorResponse(1, -32601, 'Method not found');
+		expect(res.jsonrpc).toBe('2.0');
+		expect(res.id).toBe(1);
+		expect(res.error).toEqual({ code: -32601, message: 'Method not found', data: undefined });
+		expect(res.result).toBeUndefined();
+	});
+
+	it('includes data in error when provided', () => {
+		const res = createMcpErrorResponse(2, -32602, 'Invalid params', { missing: 'name' });
+		expect(res.error?.data).toEqual({ missing: 'name' });
+	});
+});
+
+describe('textContent', () => {
+	it('creates text content object', () => {
+		const content = textContent('hello world');
+		expect(content.type).toBe('text');
+		expect(content.text).toBe('hello world');
+	});
+
+	it('handles empty string', () => {
+		const content = textContent('');
+		expect(content.text).toBe('');
+	});
+});
+
+describe('isMcpRequest', () => {
+	it('returns true for valid requests', () => {
+		expect(isMcpRequest({ jsonrpc: '2.0', id: 1, method: 'test' })).toBe(true);
+	});
+
+	it('returns true for requests with params', () => {
+		expect(isMcpRequest({ jsonrpc: '2.0', id: 1, method: 'test', params: {} })).toBe(true);
+	});
+
+	it('returns false for non-2.0 jsonrpc', () => {
+		expect(isMcpRequest({ jsonrpc: '1.0', id: 1, method: 'test' })).toBe(false);
+	});
+
+	it('returns false for missing id', () => {
+		expect(isMcpRequest({ jsonrpc: '2.0', method: 'test' })).toBe(false);
+	});
+
+	it('returns false for missing method', () => {
+		expect(isMcpRequest({ jsonrpc: '2.0', id: 1 })).toBe(false);
+	});
+
+	it('returns false for null', () => {
+		expect(isMcpRequest(null)).toBe(false);
+	});
+
+	it('returns false for primitives', () => {
+		expect(isMcpRequest('string')).toBe(false);
+		expect(isMcpRequest(42)).toBe(false);
+	});
+});
+
+describe('isMcpResponse', () => {
+	it('returns true for success response', () => {
+		expect(isMcpResponse({ jsonrpc: '2.0', id: 1, result: {} })).toBe(true);
+	});
+
+	it('returns true for error response', () => {
+		expect(isMcpResponse({ jsonrpc: '2.0', id: 1, error: { code: -1, message: 'err' } })).toBe(
+			true
+		);
+	});
+
+	it('returns false for notification (no id)', () => {
+		expect(isMcpResponse({ jsonrpc: '2.0', result: {} })).toBe(false);
+	});
+
+	it('returns false for missing both result and error', () => {
+		expect(isMcpResponse({ jsonrpc: '2.0', id: 1 })).toBe(false);
+	});
+
+	it('returns false for request (has method, no result/error)', () => {
+		expect(isMcpResponse({ jsonrpc: '2.0', id: 1, method: 'test' })).toBe(false);
+	});
+
+	it('returns false for null', () => {
+		expect(isMcpResponse(null)).toBe(false);
+	});
+});
+
+describe('isMcpNotification', () => {
+	it('returns true for valid notification', () => {
+		expect(isMcpNotification({ jsonrpc: '2.0', method: 'notify' })).toBe(true);
+	});
+
+	it('returns true for notification with params', () => {
+		expect(isMcpNotification({ jsonrpc: '2.0', method: 'notify', params: { a: 1 } })).toBe(true);
+	});
+
+	it('returns false for request (has id)', () => {
+		expect(isMcpNotification({ jsonrpc: '2.0', id: 1, method: 'test' })).toBe(false);
+	});
+
+	it('returns false for missing method', () => {
+		expect(isMcpNotification({ jsonrpc: '2.0' })).toBe(false);
+	});
+
+	it('returns false for non-2.0 jsonrpc', () => {
+		expect(isMcpNotification({ jsonrpc: '1.0', method: 'test' })).toBe(false);
+	});
+
+	it('returns false for null', () => {
+		expect(isMcpNotification(null)).toBe(false);
+	});
+});

--- a/packages/server/src/bootstrap/bootstrap.test.ts
+++ b/packages/server/src/bootstrap/bootstrap.test.ts
@@ -1,0 +1,306 @@
+import type { CommandDefinition } from '@lushly-dev/afd-core';
+import { success } from '@lushly-dev/afd-core';
+import { describe, expect, it } from 'vitest';
+import { createAfdDocsCommand } from './afd-docs.js';
+import { createAfdHelpCommand } from './afd-help.js';
+import { createAfdSchemaCommand } from './afd-schema.js';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test Fixtures
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function makeMockCommands(): CommandDefinition[] {
+	return [
+		{
+			name: 'todo-create',
+			description: 'Create a todo',
+			category: 'todos',
+			tags: ['crud', 'write'],
+			mutation: true,
+			parameters: [
+				{ name: 'title', type: 'string', description: 'Todo title', required: true },
+				{ name: 'priority', type: 'string', description: 'Priority level', required: false },
+			],
+			handler: async () => success(null),
+		},
+		{
+			name: 'todo-list',
+			description: 'List todos',
+			category: 'todos',
+			tags: ['crud', 'read'],
+			mutation: false,
+			parameters: [],
+			handler: async () => success([]),
+		},
+		{
+			name: 'user-get',
+			description: 'Get a user',
+			category: 'users',
+			tags: ['crud', 'read'],
+			mutation: false,
+			parameters: [{ name: 'id', type: 'number', description: 'User ID', required: true }],
+			handler: async () => success(null),
+		},
+	];
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// afd-help tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('createAfdHelpCommand', () => {
+	it('creates command with correct metadata', () => {
+		const cmd = createAfdHelpCommand(() => []);
+		expect(cmd.name).toBe('afd-help');
+		expect(cmd.category).toBe('bootstrap');
+		expect(cmd.mutation).toBe(false);
+	});
+
+	it('lists all commands without filter', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdHelpCommand(() => commands);
+		const result = await cmd.handler({ format: 'brief' });
+
+		expect(result.success).toBe(true);
+		expect(result.data?.total).toBe(3);
+		expect(result.data?.filtered).toBe(false);
+		expect(result.data?.commands).toHaveLength(3);
+	});
+
+	it('filters by tag', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdHelpCommand(() => commands);
+		const result = await cmd.handler({ filter: 'write', format: 'brief' });
+
+		expect(result.success).toBe(true);
+		expect(result.data?.total).toBe(1);
+		expect(result.data?.filtered).toBe(true);
+		expect(result.data?.commands[0]?.name).toBe('todo-create');
+	});
+
+	it('filters by name', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdHelpCommand(() => commands);
+		const result = await cmd.handler({ filter: 'user', format: 'brief' });
+
+		expect(result.success).toBe(true);
+		expect(result.data?.total).toBe(1);
+		expect(result.data?.commands[0]?.name).toBe('user-get');
+	});
+
+	it('filters by category', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdHelpCommand(() => commands);
+		const result = await cmd.handler({ filter: 'todos', format: 'brief' });
+
+		expect(result.success).toBe(true);
+		expect(result.data?.total).toBe(2);
+	});
+
+	it('brief format excludes extra fields', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdHelpCommand(() => commands);
+		const result = await cmd.handler({ format: 'brief' });
+
+		const info = result.data?.commands[0];
+		expect(info?.name).toBeDefined();
+		expect(info?.description).toBeDefined();
+		expect(info?.category).toBeUndefined();
+		expect(info?.tags).toBeUndefined();
+	});
+
+	it('full format includes extra fields', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdHelpCommand(() => commands);
+		const result = await cmd.handler({ format: 'full' });
+
+		const info = result.data?.commands[0];
+		expect(info?.category).toBeDefined();
+		expect(info?.tags).toBeDefined();
+		expect(info?.mutation).toBeDefined();
+	});
+
+	it('groups commands by category', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdHelpCommand(() => commands);
+		const result = await cmd.handler({ format: 'full' });
+
+		const grouped = result.data?.groupedByCategory;
+		expect(grouped).toBeDefined();
+		expect(grouped?.todos).toHaveLength(2);
+		expect(grouped?.users).toHaveLength(1);
+	});
+
+	it('uncategorized commands go to "uncategorized" group', async () => {
+		const commands: CommandDefinition[] = [
+			{
+				name: 'no-cat',
+				description: 'No category',
+				parameters: [],
+				handler: async () => success(null),
+			},
+		];
+		const cmd = createAfdHelpCommand(() => commands);
+		const result = await cmd.handler({ format: 'full' });
+
+		expect(result.data?.groupedByCategory?.uncategorized).toHaveLength(1);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// afd-docs tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('createAfdDocsCommand', () => {
+	it('creates command with correct metadata', () => {
+		const cmd = createAfdDocsCommand(() => []);
+		expect(cmd.name).toBe('afd-docs');
+		expect(cmd.mutation).toBe(false);
+	});
+
+	it('generates docs for all commands', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdDocsCommand(() => commands);
+		const result = await cmd.handler({});
+
+		expect(result.success).toBe(true);
+		expect(result.data?.commandCount).toBe(3);
+		expect(result.data?.markdown).toContain('# Command Documentation');
+		expect(result.data?.markdown).toContain('`todo-create`');
+		expect(result.data?.markdown).toContain('`user-get`');
+	});
+
+	it('generates docs for specific command', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdDocsCommand(() => commands);
+		const result = await cmd.handler({ command: 'todo-create' });
+
+		expect(result.success).toBe(true);
+		expect(result.data?.commandCount).toBe(1);
+		expect(result.data?.markdown).toContain('`todo-create`');
+		expect(result.data?.markdown).not.toContain('`user-get`');
+	});
+
+	it('returns empty docs for non-existent command', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdDocsCommand(() => commands);
+		const result = await cmd.handler({ command: 'nonexistent-cmd' });
+
+		expect(result.success).toBe(true);
+		expect(result.data?.commandCount).toBe(0);
+		expect(result.data?.markdown).toBe('');
+	});
+
+	it('includes parameter table in markdown', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdDocsCommand(() => commands);
+		const result = await cmd.handler({ command: 'todo-create' });
+
+		expect(result.data?.markdown).toContain('**Parameters:**');
+		expect(result.data?.markdown).toContain('| title |');
+		expect(result.data?.markdown).toContain('| Yes |');
+	});
+
+	it('includes tags in markdown', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdDocsCommand(() => commands);
+		const result = await cmd.handler({ command: 'todo-create' });
+
+		expect(result.data?.markdown).toContain('**Tags:**');
+		expect(result.data?.markdown).toContain('`crud`');
+	});
+
+	it('includes mutation info in markdown', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdDocsCommand(() => commands);
+		const result = await cmd.handler({ command: 'todo-create' });
+
+		expect(result.data?.markdown).toContain('**Mutation:** Yes');
+	});
+
+	it('groups by category and sorts alphabetically', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdDocsCommand(() => commands);
+		const result = await cmd.handler({});
+
+		const markdown = result.data?.markdown ?? '';
+		// "todos" category should appear before "users" alphabetically
+		const todosIdx = markdown.indexOf('## todos');
+		const usersIdx = markdown.indexOf('## users');
+		expect(todosIdx).toBeLessThan(usersIdx);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// afd-schema tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('createAfdSchemaCommand', () => {
+	it('creates command with correct metadata', () => {
+		const cmd = createAfdSchemaCommand(() => []);
+		expect(cmd.name).toBe('afd-schema');
+		expect(cmd.mutation).toBe(false);
+	});
+
+	it('exports schemas for all commands (json format)', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdSchemaCommand(() => commands);
+		const result = await cmd.handler({ format: 'json' });
+
+		expect(result.success).toBe(true);
+		expect(result.data?.count).toBe(3);
+		expect(result.data?.format).toBe('json');
+		expect(result.data?.schemas).toHaveLength(3);
+	});
+
+	it('builds basic schema from parameters', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdSchemaCommand(() => commands);
+		const result = await cmd.handler({ format: 'json' });
+
+		const todoSchema = result.data?.schemas.find((s) => s.name === 'todo-create');
+		expect(todoSchema?.inputSchema).toEqual({
+			type: 'object',
+			properties: {
+				title: { type: 'string', description: 'Todo title' },
+				priority: { type: 'string', description: 'Priority level' },
+			},
+			required: ['title'],
+		});
+	});
+
+	it('uses getJsonSchema function when provided', async () => {
+		const commands = makeMockCommands();
+		const customSchema = { type: 'custom', fields: ['a', 'b'] };
+		const cmd = createAfdSchemaCommand(
+			() => commands,
+			() => customSchema as unknown as Record<string, unknown>
+		);
+		const result = await cmd.handler({ format: 'json' });
+
+		expect(result.data?.schemas[0]?.inputSchema).toEqual(customSchema);
+	});
+
+	it('typescript format returns schemas with note', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdSchemaCommand(() => commands);
+		const result = await cmd.handler({ format: 'typescript' });
+
+		expect(result.success).toBe(true);
+		expect(result.data?.format).toBe('typescript');
+		expect(result.confidence).toBe(0.8);
+	});
+
+	it('handles commands without parameters', async () => {
+		const commands = makeMockCommands();
+		const cmd = createAfdSchemaCommand(() => commands);
+		const result = await cmd.handler({ format: 'json' });
+
+		const listSchema = result.data?.schemas.find((s) => s.name === 'todo-list');
+		expect(listSchema?.inputSchema).toEqual({
+			type: 'object',
+			properties: {},
+			required: [],
+		});
+	});
+});

--- a/packages/server/src/validation.test.ts
+++ b/packages/server/src/validation.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+	formatEnhancedValidationError,
+	formatValidationErrors,
+	isValid,
+	optional,
+	patterns,
+	ValidationException,
+	validateInput,
+	validateInputEnhanced,
+	validateOrThrow,
+	withDefault,
+} from './validation.js';
+
+describe('validateInput', () => {
+	const schema = z.object({
+		name: z.string(),
+		age: z.number(),
+	});
+
+	it('returns success with valid data', () => {
+		const result = validateInput(schema, { name: 'Alice', age: 30 });
+		expect(result.success).toBe(true);
+		expect(result.data).toEqual({ name: 'Alice', age: 30 });
+	});
+
+	it('returns errors for invalid data', () => {
+		const result = validateInput(schema, { name: 123 });
+		expect(result.success).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+		expect(result.errors[0]?.code).toBe('invalid_type');
+	});
+});
+
+describe('validateInputEnhanced', () => {
+	const schema = z.object({
+		title: z.string(),
+		count: z.number(),
+	});
+
+	it('returns success with valid data', () => {
+		const result = validateInputEnhanced(schema, { title: 'test', count: 5 });
+		expect(result.success).toBe(true);
+		expect(result.data).toEqual({ title: 'test', count: 5 });
+	});
+
+	it('reports unexpected fields on invalid input', () => {
+		// Need to make the input invalid so enhanced validation runs schemaInfo
+		const result = validateInputEnhanced(schema, { count: 'not a number', extra: true });
+		expect(result.success).toBe(false);
+		expect(result.unexpectedFields).toContain('extra');
+		expect(result.expectedFields).toContain('title');
+		expect(result.expectedFields).toContain('count');
+	});
+
+	it('reports missing required fields', () => {
+		const result = validateInputEnhanced(schema, {});
+		expect(result.success).toBe(false);
+		expect(result.missingFields).toContain('title');
+		expect(result.missingFields).toContain('count');
+	});
+
+	it('handles non-object input gracefully', () => {
+		const result = validateInputEnhanced(schema, 'not an object');
+		expect(result.success).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+});
+
+describe('validateOrThrow', () => {
+	const schema = z.object({ name: z.string() });
+
+	it('returns valid data', () => {
+		const data = validateOrThrow(schema, { name: 'test' });
+		expect(data).toEqual({ name: 'test' });
+	});
+
+	it('throws ValidationException on invalid data', () => {
+		expect(() => validateOrThrow(schema, {})).toThrow(ValidationException);
+	});
+});
+
+describe('isValid', () => {
+	const schema = z.string().min(1);
+
+	it('returns true for valid input', () => {
+		expect(isValid(schema, 'hello')).toBe(true);
+	});
+
+	it('returns false for invalid input', () => {
+		expect(isValid(schema, '')).toBe(false);
+		expect(isValid(schema, 42)).toBe(false);
+	});
+});
+
+describe('formatValidationErrors', () => {
+	it('returns "No validation errors" for empty array', () => {
+		expect(formatValidationErrors([])).toBe('No validation errors');
+	});
+
+	it('formats single root error without path prefix', () => {
+		const errors = [{ path: '(root)', message: 'Required', code: 'invalid_type' }];
+		expect(formatValidationErrors(errors)).toBe('Required');
+	});
+
+	it('formats single field error with path prefix', () => {
+		const errors = [{ path: 'name', message: 'Required', code: 'invalid_type' }];
+		expect(formatValidationErrors(errors)).toBe('name: Required');
+	});
+
+	it('formats multiple errors as bullet list', () => {
+		const errors = [
+			{ path: 'name', message: 'Required', code: 'invalid_type' },
+			{ path: '(root)', message: 'Extra fields', code: 'unrecognized_keys' },
+		];
+		const result = formatValidationErrors(errors);
+		expect(result).toContain('- name: Required');
+		expect(result).toContain('- Extra fields');
+	});
+});
+
+describe('formatEnhancedValidationError', () => {
+	it('combines validation errors and schema info', () => {
+		const result = formatEnhancedValidationError(
+			[{ path: 'name', message: 'Required', code: 'invalid_type' }],
+			{
+				unexpectedFields: ['foo'],
+				missingFields: ['name'],
+				expectedFields: ['name', 'age'],
+			}
+		);
+		expect(result).toContain('name: Required');
+		expect(result).toContain('Unknown field(s): foo');
+		expect(result).toContain('Missing required field(s): name');
+		expect(result).toContain('Expected fields: name, age');
+	});
+
+	it('handles errors only (no schema info)', () => {
+		const result = formatEnhancedValidationError([{ path: 'x', message: 'bad', code: 'custom' }]);
+		expect(result).toBe('x: bad');
+	});
+
+	it('handles schema info only (no errors)', () => {
+		const result = formatEnhancedValidationError([], {
+			unexpectedFields: ['extra'],
+		});
+		expect(result).toContain('Unknown field(s): extra');
+	});
+
+	it('handles empty schema info arrays', () => {
+		const result = formatEnhancedValidationError([], {
+			unexpectedFields: [],
+			missingFields: [],
+			expectedFields: [],
+		});
+		expect(result).toBe('');
+	});
+});
+
+describe('ValidationException', () => {
+	it('stores errors and has correct name', () => {
+		const errors = [{ path: 'x', message: 'bad', code: 'custom' }];
+		const ex = new ValidationException(errors);
+		expect(ex.name).toBe('ValidationException');
+		expect(ex.errors).toBe(errors);
+		expect(ex.code).toBe('VALIDATION_ERROR');
+		expect(ex.message).toBe('x: bad');
+	});
+
+	it('toCommandError produces correct structure', () => {
+		const errors = [{ path: 'name', message: 'Required', code: 'invalid_type' }];
+		const ex = new ValidationException(errors);
+		const cmdErr = ex.toCommandError();
+		expect(cmdErr.code).toBe('VALIDATION_ERROR');
+		expect(cmdErr.message).toBe('Input validation failed');
+		expect(cmdErr.suggestion).toBe('name: Required');
+		expect(cmdErr.details).toEqual({ errors });
+	});
+});
+
+describe('getSchemaShape edge cases', () => {
+	it('handles ZodEffects (transform/refine)', () => {
+		const schema = z
+			.object({ name: z.string() })
+			.transform((data) => ({ ...data, upper: data.name.toUpperCase() }));
+		const result = validateInputEnhanced(schema, {});
+		expect(result.missingFields).toContain('name');
+	});
+
+	it('handles ZodOptional wrapping object', () => {
+		const schema = z.object({ name: z.string() }).optional();
+		// When input is an object with missing fields, enhanced validation should still detect them
+		const result = validateInputEnhanced(schema, { extra: true });
+		expect(result.expectedFields).toContain('name');
+	});
+
+	it('handles ZodDefault wrapping object', () => {
+		const schema = z.object({ name: z.string() }).default({ name: 'default' });
+		const result = validateInputEnhanced(schema, { extra: true });
+		expect(result.expectedFields).toContain('name');
+	});
+
+	it('handles ZodNullable wrapping object', () => {
+		const schema = z.object({ name: z.string() }).nullable();
+		const result = validateInputEnhanced(schema, { extra: true });
+		expect(result.expectedFields).toContain('name');
+	});
+
+	it('handles non-object schemas', () => {
+		const schema = z.string();
+		const result = validateInputEnhanced(schema, 42);
+		expect(result.success).toBe(false);
+		// No expected/unexpected/missing fields for non-object schemas
+		expect(result.expectedFields).toBeUndefined();
+	});
+});
+
+describe('isRequiredField edge cases', () => {
+	it('optional fields are not reported as missing', () => {
+		const schema = z.object({
+			required: z.string(),
+			optional: z.string().optional(),
+		});
+		const result = validateInputEnhanced(schema, {});
+		expect(result.missingFields).toContain('required');
+		expect(result.missingFields).not.toContain('optional');
+	});
+
+	it('fields with defaults are not reported as missing', () => {
+		const schema = z.object({
+			required: z.string(),
+			withDefault: z.string().default('hello'),
+		});
+		const result = validateInputEnhanced(schema, {});
+		expect(result.missingFields).toContain('required');
+		expect(result.missingFields).not.toContain('withDefault');
+	});
+
+	it('refined fields are still required', () => {
+		const schema = z.object({
+			email: z.string().refine((s) => s.includes('@'), 'Must be an email'),
+		});
+		const result = validateInputEnhanced(schema, {});
+		expect(result.missingFields).toContain('email');
+	});
+});
+
+describe('patterns', () => {
+	it('uuid validates correct format', () => {
+		expect(patterns.uuid.safeParse('550e8400-e29b-41d4-a716-446655440000').success).toBe(true);
+		expect(patterns.uuid.safeParse('not-a-uuid').success).toBe(false);
+	});
+
+	it('email validates correct format', () => {
+		expect(patterns.email.safeParse('user@example.com').success).toBe(true);
+		expect(patterns.email.safeParse('not-an-email').success).toBe(false);
+	});
+
+	it('url validates correct format', () => {
+		expect(patterns.url.safeParse('https://example.com').success).toBe(true);
+		expect(patterns.url.safeParse('not a url').success).toBe(false);
+	});
+
+	it('nonEmpty rejects empty string', () => {
+		expect(patterns.nonEmpty.safeParse('').success).toBe(false);
+		expect(patterns.nonEmpty.safeParse('a').success).toBe(true);
+	});
+
+	it('positiveInt accepts positive integers', () => {
+		expect(patterns.positiveInt.safeParse(1).success).toBe(true);
+		expect(patterns.positiveInt.safeParse(0).success).toBe(false);
+		expect(patterns.positiveInt.safeParse(-1).success).toBe(false);
+		expect(patterns.positiveInt.safeParse(1.5).success).toBe(false);
+	});
+
+	it('nonNegativeInt accepts zero and positive', () => {
+		expect(patterns.nonNegativeInt.safeParse(0).success).toBe(true);
+		expect(patterns.nonNegativeInt.safeParse(1).success).toBe(true);
+		expect(patterns.nonNegativeInt.safeParse(-1).success).toBe(false);
+	});
+
+	it('isoDate validates ISO datetime', () => {
+		expect(patterns.isoDate.safeParse('2024-01-15T10:30:00Z').success).toBe(true);
+		expect(patterns.isoDate.safeParse('not a date').success).toBe(false);
+	});
+
+	it('pagination has correct defaults and constraints', () => {
+		const result = patterns.pagination.safeParse({});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.limit).toBe(20);
+			expect(result.data.offset).toBe(0);
+		}
+
+		expect(patterns.pagination.safeParse({ limit: 0 }).success).toBe(false);
+		expect(patterns.pagination.safeParse({ limit: 101 }).success).toBe(false);
+		expect(patterns.pagination.safeParse({ offset: -1 }).success).toBe(false);
+	});
+});
+
+describe('optional helper', () => {
+	it('wraps schema as optional', () => {
+		const schema = optional(z.string());
+		expect(schema.safeParse(undefined).success).toBe(true);
+		expect(schema.safeParse('hello').success).toBe(true);
+	});
+});
+
+describe('withDefault helper', () => {
+	it('applies default value', () => {
+		const schema = withDefault(z.number(), 42);
+		const result = schema.safeParse(undefined);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toBe(42);
+		}
+	});
+});

--- a/packages/testing/src/runner/executor.test.ts
+++ b/packages/testing/src/runner/executor.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Scenario, Step } from '../types/scenario.js';
+import type { CommandHandler } from './executor.js';
+import { InProcessExecutor, validateScenario } from './executor.js';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test Fixtures
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function makePassingHandler(): CommandHandler {
+	return async (command, input) => ({
+		success: true,
+		data: { id: '123', command, ...(input ?? {}) },
+		confidence: 1.0,
+		reasoning: 'Test passed',
+	});
+}
+
+function makeFailingHandler(): CommandHandler {
+	return async () => ({
+		success: false,
+		error: {
+			code: 'TEST_FAIL',
+			message: 'Intentional failure',
+		},
+	});
+}
+
+function makeThrowingHandler(): CommandHandler {
+	return async () => {
+		throw new Error('Handler exploded');
+	};
+}
+
+function makeScenario(overrides?: Partial<Scenario>): Scenario {
+	return {
+		name: 'Test Scenario',
+		description: 'A test scenario',
+		job: 'test-job',
+		tags: ['test'],
+		steps: [
+			{
+				command: 'test-cmd',
+				input: { title: 'Hello' },
+				expect: { success: true },
+			},
+		],
+		...overrides,
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// InProcessExecutor
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('InProcessExecutor', () => {
+	it('executes passing scenario', async () => {
+		const executor = new InProcessExecutor({
+			handler: makePassingHandler(),
+		});
+
+		const result = await executor.execute(makeScenario());
+
+		expect(result.outcome).toBe('pass');
+		expect(result.passedSteps).toBe(1);
+		expect(result.failedSteps).toBe(0);
+		expect(result.skippedSteps).toBe(0);
+		expect(result.durationMs).toBeGreaterThanOrEqual(0);
+		expect(result.jobName).toBe('test-job');
+	});
+
+	it('handles failing command', async () => {
+		const executor = new InProcessExecutor({
+			handler: makeFailingHandler(),
+		});
+
+		const scenario = makeScenario({
+			steps: [
+				{
+					command: 'test-cmd',
+					input: {},
+					expect: { success: true },
+				},
+			],
+		});
+
+		const result = await executor.execute(scenario);
+
+		expect(result.outcome).toBe('fail');
+		expect(result.failedSteps).toBe(1);
+	});
+
+	it('handles handler exception as error', async () => {
+		const executor = new InProcessExecutor({
+			handler: makeThrowingHandler(),
+		});
+
+		const result = await executor.execute(makeScenario());
+
+		expect(result.outcome).toBe('fail');
+		expect(result.stepResults[0]?.outcome).toBe('error');
+		expect(result.stepResults[0]?.error?.message).toContain('Handler exploded');
+	});
+
+	it('stopOnFailure skips remaining steps', async () => {
+		const handler: CommandHandler = async (command) => {
+			if (command === 'fail-cmd') {
+				return { success: false, error: { code: 'FAIL', message: 'fail' } };
+			}
+			return { success: true, data: 'ok' };
+		};
+
+		const executor = new InProcessExecutor({
+			handler,
+			stopOnFailure: true,
+		});
+
+		const scenario = makeScenario({
+			steps: [
+				{ command: 'fail-cmd', input: {}, expect: { success: true } },
+				{ command: 'pass-cmd', input: {}, expect: { success: true } },
+				{ command: 'pass-cmd', input: {}, expect: { success: true } },
+			],
+		});
+
+		const result = await executor.execute(scenario);
+
+		expect(result.failedSteps).toBe(1);
+		expect(result.skippedSteps).toBe(2);
+		expect(result.stepResults[1]?.outcome).toBe('skip');
+		expect(result.stepResults[1]?.skippedReason).toBe('Previous step failed');
+	});
+
+	it('continueOnFailure does not skip remaining', async () => {
+		const handler: CommandHandler = async (command) => {
+			if (command === 'fail-cmd') {
+				return { success: false, error: { code: 'FAIL', message: 'fail' } };
+			}
+			return { success: true, data: 'ok' };
+		};
+
+		const executor = new InProcessExecutor({
+			handler,
+			stopOnFailure: true,
+		});
+
+		const scenario = makeScenario({
+			steps: [
+				{
+					command: 'fail-cmd',
+					input: {},
+					expect: { success: true },
+					continueOnFailure: true,
+				},
+				{ command: 'pass-cmd', input: {}, expect: { success: true } },
+			],
+		});
+
+		const result = await executor.execute(scenario);
+
+		expect(result.failedSteps).toBe(1);
+		expect(result.skippedSteps).toBe(0);
+		expect(result.passedSteps).toBe(1);
+		expect(result.outcome).toBe('partial');
+	});
+
+	it('resolves step references', async () => {
+		const handler: CommandHandler = async (_command, input) => ({
+			success: true,
+			data: { id: 'abc-123', ...(input ?? {}) },
+		});
+
+		const executor = new InProcessExecutor({ handler });
+
+		const scenario = makeScenario({
+			steps: [
+				{
+					command: 'create-cmd',
+					input: { title: 'Test' },
+					expect: { success: true },
+				},
+				{
+					command: 'get-cmd',
+					input: { id: '${{ steps[0].data.id }}' },
+					expect: { success: true },
+				},
+			],
+		});
+
+		const result = await executor.execute(scenario);
+
+		expect(result.outcome).toBe('pass');
+		expect(result.passedSteps).toBe(2);
+		// The second step should have received the resolved id
+		const secondStep = result.stepResults[1];
+		expect(secondStep?.commandResult?.data).toEqual({ id: 'abc-123' });
+	});
+
+	it('dry run validates without executing', async () => {
+		const handler = vi.fn(makePassingHandler());
+
+		const executor = new InProcessExecutor({
+			handler,
+			dryRun: true,
+		});
+
+		const result = await executor.execute(makeScenario());
+
+		expect(result.outcome).toBe('pass');
+		expect(result.passedSteps).toBe(1);
+		expect(handler).not.toHaveBeenCalled();
+	});
+
+	it('calls callbacks', async () => {
+		const onScenarioStart = vi.fn();
+		const onStepComplete = vi.fn();
+		const onScenarioComplete = vi.fn();
+
+		const executor = new InProcessExecutor({
+			handler: makePassingHandler(),
+			onScenarioStart,
+			onStepComplete,
+			onScenarioComplete,
+		});
+
+		await executor.execute(makeScenario());
+
+		expect(onScenarioStart).toHaveBeenCalledOnce();
+		expect(onStepComplete).toHaveBeenCalledOnce();
+		expect(onScenarioComplete).toHaveBeenCalledOnce();
+	});
+
+	it('determineOutcome returns correct values', async () => {
+		const handler: CommandHandler = async (command) => {
+			if (command === 'fail-cmd') {
+				return { success: false, error: { code: 'FAIL', message: 'fail' } };
+			}
+			return { success: true, data: 'ok' };
+		};
+
+		// All pass
+		const executor1 = new InProcessExecutor({ handler, stopOnFailure: false });
+		const allPass = await executor1.execute(
+			makeScenario({
+				steps: [
+					{ command: 'pass-cmd', input: {}, expect: { success: true } },
+					{ command: 'pass-cmd', input: {}, expect: { success: true } },
+				],
+			})
+		);
+		expect(allPass.outcome).toBe('pass');
+
+		// All fail
+		const allFail = await executor1.execute(
+			makeScenario({
+				steps: [
+					{ command: 'fail-cmd', input: {}, expect: { success: true } },
+					{ command: 'fail-cmd', input: {}, expect: { success: true } },
+				],
+			})
+		);
+		expect(allFail.outcome).toBe('fail');
+
+		// Partial
+		const partial = await executor1.execute(
+			makeScenario({
+				steps: [
+					{ command: 'pass-cmd', input: {}, expect: { success: true } },
+					{ command: 'fail-cmd', input: {}, expect: { success: true } },
+				],
+			})
+		);
+		expect(partial.outcome).toBe('partial');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// validateScenario
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('validateScenario', () => {
+	it('valid scenario passes validation', async () => {
+		const result = await validateScenario(makeScenario(), { checkFixtures: false });
+		expect(result.valid).toBe(true);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it('reports missing name', async () => {
+		const result = await validateScenario(makeScenario({ name: '' }), { checkFixtures: false });
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain('Missing required field: name');
+	});
+
+	it('reports missing job', async () => {
+		const result = await validateScenario(makeScenario({ job: '' }), { checkFixtures: false });
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain('Missing required field: job');
+	});
+
+	it('reports empty steps', async () => {
+		const result = await validateScenario(makeScenario({ steps: [] }), { checkFixtures: false });
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain('Scenario must have at least one step');
+	});
+
+	it('reports missing step command', async () => {
+		const result = await validateScenario(
+			makeScenario({
+				steps: [{ command: '', input: {}, expect: { success: true } }],
+			}),
+			{ checkFixtures: false }
+		);
+		expect(result.errors.some((e) => e.includes("Missing required field 'command'"))).toBe(true);
+	});
+
+	it('warns about missing expect', async () => {
+		const result = await validateScenario(
+			makeScenario({
+				steps: [{ command: 'test-cmd' } as Step],
+			}),
+			{ checkFixtures: false }
+		);
+		expect(result.warnings.some((w) => w.includes("Missing 'expect'"))).toBe(true);
+	});
+
+	it('reports forward step references', async () => {
+		const result = await validateScenario(
+			makeScenario({
+				steps: [
+					{
+						command: 'cmd-one',
+						input: { ref: '${{ steps[1].data.id }}' },
+						expect: { success: true },
+					},
+					{ command: 'cmd-two', input: {}, expect: { success: true } },
+				],
+			}),
+			{ checkFixtures: false }
+		);
+		expect(result.errors.some((e) => e.includes('Invalid reference'))).toBe(true);
+	});
+
+	it('returns metadata', async () => {
+		const result = await validateScenario(makeScenario(), { checkFixtures: false });
+		expect(result.metadata.name).toBe('Test Scenario');
+		expect(result.metadata.job).toBe('test-job');
+		expect(result.metadata.stepCount).toBe(1);
+		expect(result.metadata.hasFixture).toBe(false);
+		expect(result.metadata.tags).toEqual(['test']);
+	});
+});

--- a/packages/testing/src/runner/reporter.test.ts
+++ b/packages/testing/src/runner/reporter.test.ts
@@ -1,0 +1,461 @@
+import { Writable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import type { ScenarioResult, TestReport } from '../types/report.js';
+import {
+	createJsonReporter,
+	createReporter,
+	createVerboseReporter,
+	TerminalReporter,
+} from './reporter.js';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test Helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Capture output from a reporter into a string array.
+ */
+function createCaptureStream(): { stream: NodeJS.WritableStream; lines: string[] } {
+	const lines: string[] = [];
+	const stream = new Writable({
+		write(chunk, _encoding, callback) {
+			lines.push(chunk.toString());
+			callback();
+		},
+	});
+	return { stream, lines };
+}
+
+function makeScenarioResult(overrides?: Partial<ScenarioResult>): ScenarioResult {
+	return {
+		scenarioPath: 'test.yaml',
+		jobName: 'test-job',
+		jobDescription: 'Test scenario description',
+		outcome: 'pass',
+		durationMs: 150,
+		stepResults: [
+			{
+				stepId: 'step-1',
+				command: 'test-cmd',
+				outcome: 'pass',
+				durationMs: 100,
+				assertions: [
+					{
+						path: 'success',
+						matcher: 'equals',
+						passed: true,
+						expected: true,
+						actual: true,
+						description: 'success is true',
+					},
+				],
+			},
+		],
+		passedSteps: 1,
+		failedSteps: 0,
+		skippedSteps: 0,
+		startedAt: new Date('2024-01-01'),
+		completedAt: new Date('2024-01-01'),
+		...overrides,
+	};
+}
+
+function makeFailedResult(): ScenarioResult {
+	return makeScenarioResult({
+		outcome: 'fail',
+		passedSteps: 0,
+		failedSteps: 1,
+		stepResults: [
+			{
+				stepId: 'step-1',
+				command: 'fail-cmd',
+				outcome: 'fail',
+				durationMs: 50,
+				assertions: [
+					{
+						path: 'success',
+						matcher: 'equals',
+						passed: false,
+						expected: true,
+						actual: false,
+						description: 'success should be true',
+					},
+				],
+				error: {
+					type: 'expectation_mismatch',
+					message: 'Expected success to be true',
+				},
+			},
+		],
+	});
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TerminalReporter - JSON format
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('TerminalReporter - JSON format', () => {
+	it('outputs valid JSON for single scenario', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'json', output: stream });
+
+		reporter.reportScenario(makeScenarioResult());
+
+		const output = lines.join('');
+		const parsed = JSON.parse(output);
+		expect(parsed.jobName).toBe('test-job');
+		expect(parsed.outcome).toBe('pass');
+	});
+
+	it('outputs valid JSON array for multiple scenarios', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'json', output: stream });
+
+		reporter.reportAll([makeScenarioResult(), makeFailedResult()]);
+
+		const output = lines.join('');
+		const parsed = JSON.parse(output);
+		expect(Array.isArray(parsed)).toBe(true);
+		expect(parsed).toHaveLength(2);
+	});
+
+	it('outputs valid JSON for test report', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'json', output: stream });
+
+		const report: TestReport = {
+			title: 'Test Suite',
+			durationMs: 300,
+			scenarios: [makeScenarioResult()],
+			summary: {
+				totalScenarios: 1,
+				passedScenarios: 1,
+				failedScenarios: 0,
+				errorScenarios: 0,
+				totalSteps: 1,
+				passedSteps: 1,
+				failedSteps: 0,
+				skippedSteps: 0,
+				passRate: 1.0,
+			},
+			generatedAt: new Date('2024-01-01'),
+		};
+
+		reporter.reportTestReport(report);
+
+		const output = lines.join('');
+		const parsed = JSON.parse(output);
+		expect(parsed.title).toBe('Test Suite');
+	});
+
+	it('does not output step progress in JSON mode', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'json', output: stream });
+
+		const stepResult = makeScenarioResult().stepResults[0];
+		if (!stepResult) throw new Error('Test setup error');
+		reporter.reportStepProgress(
+			{ command: 'test-cmd', expect: { success: true } },
+			stepResult,
+			0,
+			1
+		);
+
+		expect(lines).toHaveLength(0);
+	});
+
+	it('does not output scenario start in JSON mode', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'json', output: stream });
+
+		reporter.reportScenarioStart('test-job', 'description');
+
+		expect(lines).toHaveLength(0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TerminalReporter - Human format
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('TerminalReporter - Human format', () => {
+	it('shows pass icon for passing scenario', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		reporter.reportScenario(makeScenarioResult());
+
+		const output = lines.join('');
+		expect(output).toContain('✓');
+		expect(output).toContain('test-job');
+		expect(output).toContain('1 passed');
+	});
+
+	it('shows fail icon and details for failing scenario', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		reporter.reportScenario(makeFailedResult());
+
+		const output = lines.join('');
+		expect(output).toContain('✗');
+		expect(output).toContain('1 failed');
+		expect(output).toContain('Failed steps:');
+		expect(output).toContain('fail-cmd');
+	});
+
+	it('shows description when present', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		reporter.reportScenario(makeScenarioResult({ jobDescription: 'My test description' }));
+
+		const output = lines.join('');
+		expect(output).toContain('My test description');
+	});
+
+	it('verbose mode shows all step details', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({
+			format: 'human',
+			colors: false,
+			verbose: true,
+			output: stream,
+		});
+
+		reporter.reportScenario(makeScenarioResult());
+
+		const output = lines.join('');
+		expect(output).toContain('test-cmd');
+		expect(output).toContain('success is true');
+	});
+
+	it('verbose step progress shows assertions', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({
+			format: 'human',
+			colors: false,
+			verbose: true,
+			output: stream,
+		});
+
+		const step = makeScenarioResult().stepResults[0];
+		if (!step) throw new Error('Test setup error');
+		reporter.reportStepProgress({ command: 'test-cmd', expect: { success: true } }, step, 0, 1);
+
+		const output = lines.join('');
+		expect(output).toContain('[1/1]');
+		expect(output).toContain('test-cmd');
+		expect(output).toContain('success is true');
+	});
+
+	it('non-verbose step progress shows failed assertions', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({
+			format: 'human',
+			colors: false,
+			verbose: false,
+			output: stream,
+		});
+
+		const failStep = makeFailedResult().stepResults[0];
+		if (!failStep) throw new Error('Test setup error');
+		reporter.reportStepProgress({ command: 'fail-cmd', expect: { success: true } }, failStep, 0, 1);
+
+		const output = lines.join('');
+		expect(output).toContain('✗');
+		expect(output).toContain('Error:');
+	});
+
+	it('summary shows total pass/fail counts', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		reporter.reportAll([makeScenarioResult(), makeScenarioResult()]);
+
+		const output = lines.join('');
+		expect(output).toContain('2 passed');
+		expect(output).toContain('0 failed');
+		expect(output).toContain('All scenarios passed!');
+	});
+
+	it('summary shows failure message when some fail', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		reporter.reportAll([makeScenarioResult(), makeFailedResult()]);
+
+		const output = lines.join('');
+		expect(output).toContain('1 failed');
+		expect(output).toContain('scenario(s) failed');
+	});
+
+	it('scenario start outputs job name', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		reporter.reportScenarioStart('my-job', 'My job description');
+
+		const output = lines.join('');
+		expect(output).toContain('my-job');
+		expect(output).toContain('My job description');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Duration formatting
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('TerminalReporter - duration formatting', () => {
+	it('formats milliseconds', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		reporter.reportScenario(makeScenarioResult({ durationMs: 500 }));
+
+		const output = lines.join('');
+		expect(output).toContain('500ms');
+	});
+
+	it('formats seconds', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		reporter.reportScenario(makeScenarioResult({ durationMs: 2500 }));
+
+		const output = lines.join('');
+		expect(output).toContain('2.5s');
+	});
+
+	it('formats minutes', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		reporter.reportScenario(makeScenarioResult({ durationMs: 90000 }));
+
+		const output = lines.join('');
+		expect(output).toContain('1.5m');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Outcome icons
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('TerminalReporter - outcome icons', () => {
+	it.each([
+		['pass', '✓'],
+		['fail', '✗'],
+		['error', '⚠'],
+		['skip', '○'],
+		['partial', '◐'],
+	])('shows correct icon for %s outcome', (outcome, icon) => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		reporter.reportScenario(makeScenarioResult({ outcome: outcome as ScenarioResult['outcome'] }));
+
+		const output = lines.join('');
+		expect(output).toContain(icon);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Factory functions
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('Factory functions', () => {
+	it('createReporter creates default reporter', () => {
+		const reporter = createReporter();
+		expect(reporter).toBeInstanceOf(TerminalReporter);
+	});
+
+	it('createJsonReporter creates JSON reporter', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = createJsonReporter(stream);
+
+		reporter.reportScenario(makeScenarioResult());
+
+		const output = lines.join('');
+		const parsed = JSON.parse(output);
+		expect(parsed.outcome).toBe('pass');
+	});
+
+	it('createVerboseReporter creates verbose human reporter', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = createVerboseReporter(stream);
+
+		reporter.reportScenario(makeScenarioResult());
+
+		const output = lines.join('');
+		// Verbose shows step details
+		expect(output).toContain('test-cmd');
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test report with summary
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('TerminalReporter - reportTestReport (human)', () => {
+	it('shows title and summary', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		const report: TestReport = {
+			title: 'Integration Tests',
+			durationMs: 5000,
+			scenarios: [makeScenarioResult(), makeFailedResult()],
+			summary: {
+				totalScenarios: 2,
+				passedScenarios: 1,
+				failedScenarios: 1,
+				errorScenarios: 0,
+				totalSteps: 2,
+				passedSteps: 1,
+				failedSteps: 1,
+				skippedSteps: 0,
+				passRate: 0.5,
+			},
+			generatedAt: new Date('2024-01-01'),
+		};
+
+		reporter.reportTestReport(report);
+
+		const output = lines.join('');
+		expect(output).toContain('Integration Tests');
+		expect(output).toContain('Summary');
+		expect(output).toContain('1 passed');
+		expect(output).toContain('1 failed');
+		expect(output).toContain('50.0%');
+		expect(output).toContain('scenario(s) failed');
+	});
+
+	it('shows all passed message when no failures', () => {
+		const { stream, lines } = createCaptureStream();
+		const reporter = new TerminalReporter({ format: 'human', colors: false, output: stream });
+
+		const report: TestReport = {
+			title: 'All Green',
+			durationMs: 1000,
+			scenarios: [makeScenarioResult()],
+			summary: {
+				totalScenarios: 1,
+				passedScenarios: 1,
+				failedScenarios: 0,
+				errorScenarios: 0,
+				totalSteps: 1,
+				passedSteps: 1,
+				failedSteps: 0,
+				skippedSteps: 0,
+				passRate: 1.0,
+			},
+			generatedAt: new Date('2024-01-01'),
+		};
+
+		reporter.reportTestReport(report);
+
+		const output = lines.join('');
+		expect(output).toContain('All scenarios passed!');
+	});
+});


### PR DESCRIPTION
## What

Adds **246 new unit tests** across 9 test files (7 new, 1 expanded, 1 new bootstrap suite), targeting previously untested modules in core, client, server, and testing packages.

| Package | New Tests | Key Modules Covered |
|---------|-----------|-------------------|
| `core` | 83 | `errors.ts` factories, `mcp.ts` helpers, `commands.ts` registry CRUD / batch / stream / MCP tool conversion |
| `client` | 32 | `McpClient` constructor / status / call / batch / pipe, `SseTransport` + `HttpTransport` lifecycle |
| `server` | 61 | `validation.ts` enhanced errors / schema introspection / patterns, bootstrap commands (`afd-help`, `afd-docs`, `afd-schema`) |
| `testing` | 70 | `InProcessExecutor` pass/fail/skip/references/dry-run, `validateScenario`, `TerminalReporter` JSON + human formats |

## Why

Coverage gaps existed in key logic modules — error factories at 0%, MCP helpers at 0%, client at 43%, testing runner at 31%. These are foundational modules where regressions would be costly and silent.

## How

- Pure unit tests with no external dependencies — mock handlers, capture streams, in-memory registries
- Tests follow existing patterns: Vitest explicit imports, tab indentation, `import type` for type-only
- Each test file is self-contained with factory helpers for fixtures

## Testing

All tests verified:
- `pnpm test` — 1,195 tests passing (246 new)
- `pnpm typecheck` — clean across all packages
- `biome check` — 0 lint errors on all 9 test files

## Checklist

- [x] Tests pass locally
- [x] No lint errors introduced
- [x] No type errors introduced
- [x] No changes to production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)