### PR TITLE
feat(core): add ReconnectPolicy, createHandoff(), BatchWarning, core executePipeline()

### DIFF
--- a/packages/core/src/batch.test.ts
+++ b/packages/core/src/batch.test.ts
@@ -3,6 +3,7 @@ import {
 	type BatchCommand,
 	type BatchCommandResult,
 	type BatchTiming,
+	type BatchWarning,
 	calculateBatchConfidence,
 	createBatchRequest,
 	createBatchResult,
@@ -235,6 +236,51 @@ describe('type guards', () => {
 			expect(isBatchResult({ success: true })).toBe(false);
 			expect(isBatchResult({ success: true, results: 'not array' })).toBe(false);
 		});
+	});
+});
+
+describe('BatchWarning', () => {
+	it('is usable as a typed warning in batch results', () => {
+		const warning: BatchWarning = {
+			commandId: 'cmd-0',
+			code: 'RATE_LIMIT_APPROACHING',
+			message: 'Command is nearing rate limit threshold',
+		};
+
+		expect(warning.commandId).toBe('cmd-0');
+		expect(warning.code).toBe('RATE_LIMIT_APPROACHING');
+		expect(warning.message).toBe('Command is nearing rate limit threshold');
+	});
+
+	it('is compatible with createBatchResult warnings', () => {
+		const results: BatchCommandResult[] = [
+			{
+				id: 'cmd-0',
+				index: 0,
+				command: 'test',
+				durationMs: 10,
+				result: {
+					success: true,
+					data: {},
+					warnings: [{ code: 'WARN_TEST', message: 'Test warning', severity: 'info' as const }],
+				},
+			},
+		];
+
+		const timing: BatchTiming = {
+			totalMs: 10,
+			averageMs: 10,
+			startedAt: '2024-01-01T00:00:00.000Z',
+			completedAt: '2024-01-01T00:00:00.010Z',
+		};
+
+		const result = createBatchResult(results, timing);
+
+		expect(result.warnings).toHaveLength(1);
+		const w = result.warnings?.[0] as BatchWarning;
+		expect(w.commandId).toBe('cmd-0');
+		expect(w.code).toBe('WARN_TEST');
+		expect(w.message).toBe('Test warning');
 	});
 });
 

--- a/packages/core/src/batch.ts
+++ b/packages/core/src/batch.ts
@@ -100,6 +100,32 @@ export interface BatchRequest {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
+ * A typed warning from a command within a batch execution.
+ *
+ * Carries the originating command ID for attribution, following
+ * the same pattern as PipelineWarning carries stepIndex.
+ *
+ * @example
+ * ```typescript
+ * const warning: BatchWarning = {
+ *   commandId: 'cmd-0',
+ *   code: 'RATE_LIMIT_APPROACHING',
+ *   message: 'Command is nearing rate limit threshold',
+ * };
+ * ```
+ */
+export interface BatchWarning {
+	/** ID of the command that generated this warning */
+	commandId: string;
+
+	/** Machine-readable warning code (SCREAMING_SNAKE_CASE) */
+	code: string;
+
+	/** Human-readable warning message */
+	message: string;
+}
+
+/**
  * Result of a single command within a batch.
  *
  * Extends the standard CommandResult with batch-specific metadata.
@@ -238,11 +264,7 @@ export interface BatchResult<T = unknown> {
 	/**
 	 * Warnings from any of the commands.
 	 */
-	warnings?: Array<{
-		commandId: string;
-		code: string;
-		message: string;
-	}>;
+	warnings?: BatchWarning[];
 
 	/**
 	 * Error if the batch itself failed to execute.

--- a/packages/core/src/handoff.test.ts
+++ b/packages/core/src/handoff.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
+	createHandoff,
 	getHandoffProtocol,
 	type HandoffResult,
 	isHandoff,
 	isHandoffCommand,
 	isHandoffProtocol,
+	isReconnectPolicy,
+	type ReconnectPolicy,
 } from './handoff.js';
 
 describe('isHandoff', () => {
@@ -379,5 +382,150 @@ describe('getHandoffProtocol', () => {
 
 	it('extracts protocol correctly from tag with colons', () => {
 		expect(getHandoffProtocol({ tags: ['handoff', 'handoff:http-stream'] })).toBe('http-stream');
+	});
+});
+
+describe('isReconnectPolicy', () => {
+	it('returns true for valid minimal policy', () => {
+		const policy: ReconnectPolicy = { allowed: true };
+		expect(isReconnectPolicy(policy)).toBe(true);
+	});
+
+	it('returns true for full policy', () => {
+		const policy: ReconnectPolicy = {
+			allowed: true,
+			maxAttempts: 5,
+			backoffMs: 1000,
+		};
+		expect(isReconnectPolicy(policy)).toBe(true);
+	});
+
+	it('returns true when allowed is false', () => {
+		expect(isReconnectPolicy({ allowed: false })).toBe(true);
+	});
+
+	it('returns false for null', () => {
+		expect(isReconnectPolicy(null)).toBe(false);
+	});
+
+	it('returns false for undefined', () => {
+		expect(isReconnectPolicy(undefined)).toBe(false);
+	});
+
+	it('returns false for non-object', () => {
+		expect(isReconnectPolicy('string')).toBe(false);
+		expect(isReconnectPolicy(123)).toBe(false);
+	});
+
+	it('returns false when allowed is missing', () => {
+		expect(isReconnectPolicy({ maxAttempts: 5 })).toBe(false);
+	});
+
+	it('returns false when allowed is wrong type', () => {
+		expect(isReconnectPolicy({ allowed: 'yes' })).toBe(false);
+	});
+
+	it('returns false when maxAttempts is wrong type', () => {
+		expect(isReconnectPolicy({ allowed: true, maxAttempts: 'five' })).toBe(false);
+	});
+
+	it('returns false when backoffMs is wrong type', () => {
+		expect(isReconnectPolicy({ allowed: true, backoffMs: 'slow' })).toBe(false);
+	});
+});
+
+describe('createHandoff', () => {
+	it('creates minimal handoff with protocol and endpoint', () => {
+		const handoff = createHandoff('websocket', 'wss://example.com/chat');
+
+		expect(handoff.protocol).toBe('websocket');
+		expect(handoff.endpoint).toBe('wss://example.com/chat');
+		expect(handoff.credentials).toBeUndefined();
+		expect(handoff.metadata).toBeUndefined();
+	});
+
+	it('creates handoff with credentials', () => {
+		const handoff = createHandoff('websocket', 'wss://example.com/chat', {
+			credentials: {
+				token: 'abc123',
+				sessionId: 'session-xyz',
+			},
+		});
+
+		expect(handoff.credentials?.token).toBe('abc123');
+		expect(handoff.credentials?.sessionId).toBe('session-xyz');
+	});
+
+	it('creates handoff with metadata', () => {
+		const handoff = createHandoff('sse', 'https://example.com/stream', {
+			metadata: {
+				capabilities: ['text', 'presence'],
+				description: 'Real-time stream',
+			},
+		});
+
+		expect(handoff.metadata?.capabilities).toEqual(['text', 'presence']);
+		expect(handoff.metadata?.description).toBe('Real-time stream');
+	});
+
+	it('applies default reconnect policy when reconnect is true', () => {
+		const handoff = createHandoff('websocket', 'wss://example.com/chat', {
+			metadata: {
+				reconnect: true,
+			},
+		});
+
+		expect(handoff.metadata?.reconnect).toBeDefined();
+		expect(handoff.metadata?.reconnect?.allowed).toBe(true);
+		expect(handoff.metadata?.reconnect?.maxAttempts).toBe(3);
+		expect(handoff.metadata?.reconnect?.backoffMs).toBe(1000);
+	});
+
+	it('uses custom reconnect policy when provided', () => {
+		const customPolicy: ReconnectPolicy = {
+			allowed: true,
+			maxAttempts: 10,
+			backoffMs: 2000,
+		};
+
+		const handoff = createHandoff('websocket', 'wss://example.com/chat', {
+			metadata: {
+				reconnect: customPolicy,
+			},
+		});
+
+		expect(handoff.metadata?.reconnect).toEqual(customPolicy);
+	});
+
+	it('omits reconnect from metadata when not provided', () => {
+		const handoff = createHandoff('websocket', 'wss://example.com/chat', {
+			metadata: {
+				description: 'No reconnect',
+			},
+		});
+
+		expect(handoff.metadata?.reconnect).toBeUndefined();
+	});
+
+	it('produces valid HandoffResult (passes isHandoff)', () => {
+		const handoff = createHandoff('websocket', 'wss://example.com/chat', {
+			credentials: { token: 'abc' },
+			metadata: {
+				reconnect: true,
+				capabilities: ['text'],
+			},
+		});
+
+		expect(isHandoff(handoff)).toBe(true);
+	});
+
+	it('supports all standard protocols', () => {
+		const protocols = ['websocket', 'webrtc', 'sse', 'http-stream'] as const;
+
+		for (const protocol of protocols) {
+			const handoff = createHandoff(protocol, 'https://example.com');
+			expect(handoff.protocol).toBe(protocol);
+			expect(isHandoff(handoff)).toBe(true);
+		}
 	});
 });

--- a/packages/core/src/handoff.ts
+++ b/packages/core/src/handoff.ts
@@ -19,6 +19,30 @@
 export type HandoffProtocol = 'websocket' | 'webrtc' | 'sse' | 'http-stream' | string;
 
 /**
+ * Named reconnect policy type for handoff metadata.
+ *
+ * Extracted as a first-class type so it can be validated, shared across
+ * packages, and consumed directly by handoff metadata and client reconnection logic.
+ *
+ * @example
+ * ```typescript
+ * const policy: ReconnectPolicy = {
+ *   allowed: true,
+ *   maxAttempts: 5,
+ *   backoffMs: 1000,
+ * };
+ * ```
+ */
+export interface ReconnectPolicy {
+	/** Whether reconnection is allowed */
+	allowed: boolean;
+	/** Maximum number of reconnection attempts */
+	maxAttempts?: number;
+	/** Base backoff time in milliseconds */
+	backoffMs?: number;
+}
+
+/**
  * Authentication credentials for the handoff connection.
  *
  * @example
@@ -70,14 +94,7 @@ export interface HandoffMetadata {
 	expiresAt?: string;
 
 	/** Reconnection policy */
-	reconnect?: {
-		/** Whether reconnection is allowed */
-		allowed: boolean;
-		/** Maximum number of reconnection attempts */
-		maxAttempts?: number;
-		/** Base backoff time in milliseconds */
-		backoffMs?: number;
-	};
+	reconnect?: ReconnectPolicy;
 
 	/** Human-readable description of the handoff */
 	description?: string;
@@ -114,8 +131,117 @@ export interface HandoffResult {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// FACTORY FUNCTIONS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Default reconnect policy values.
+ */
+const DEFAULT_RECONNECT_POLICY: ReconnectPolicy = {
+	allowed: true,
+	maxAttempts: 3,
+	backoffMs: 1000,
+};
+
+/**
+ * Create a HandoffResult with sensible defaults.
+ *
+ * @param protocol - Protocol type for client dispatch
+ * @param endpoint - Full URL to connect to
+ * @param options - Optional credentials, metadata, and reconnect policy
+ * @returns A complete HandoffResult
+ *
+ * @example
+ * ```typescript
+ * // Minimal handoff
+ * const handoff = createHandoff('websocket', 'wss://example.com/chat');
+ *
+ * // With credentials and metadata
+ * const handoff = createHandoff('websocket', 'wss://example.com/chat', {
+ *   credentials: { token: 'abc123', sessionId: 'session-xyz' },
+ *   metadata: {
+ *     capabilities: ['text', 'presence'],
+ *     reconnect: { allowed: true, maxAttempts: 5, backoffMs: 2000 },
+ *   },
+ * });
+ *
+ * // With default reconnect policy
+ * const handoff = createHandoff('sse', 'https://example.com/stream', {
+ *   metadata: { reconnect: true },
+ * });
+ * ```
+ */
+export function createHandoff(
+	protocol: HandoffProtocol,
+	endpoint: string,
+	options?: {
+		credentials?: HandoffCredentials;
+		metadata?: Omit<HandoffMetadata, 'reconnect'> & {
+			/** Pass `true` for default reconnect policy, or provide a custom ReconnectPolicy */
+			reconnect?: boolean | ReconnectPolicy;
+		};
+	}
+): HandoffResult {
+	const result: HandoffResult = { protocol, endpoint };
+
+	if (options?.credentials) {
+		result.credentials = options.credentials;
+	}
+
+	if (options?.metadata) {
+		const { reconnect, ...rest } = options.metadata;
+		const metadata: HandoffMetadata = { ...rest };
+
+		if (reconnect === true) {
+			metadata.reconnect = { ...DEFAULT_RECONNECT_POLICY };
+		} else if (typeof reconnect === 'object') {
+			metadata.reconnect = reconnect;
+		}
+
+		result.metadata = metadata;
+	}
+
+	return result;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // TYPE GUARDS
 // ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Type guard to check if a value is a valid ReconnectPolicy.
+ *
+ * @param value - Value to check
+ * @returns True if value is a ReconnectPolicy
+ *
+ * @example
+ * ```typescript
+ * if (isReconnectPolicy(handoff.metadata?.reconnect)) {
+ *   console.log(`Max attempts: ${handoff.metadata.reconnect.maxAttempts}`);
+ * }
+ * ```
+ */
+export function isReconnectPolicy(value: unknown): value is ReconnectPolicy {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	const obj = value as Record<string, unknown>;
+
+	if (typeof obj.allowed !== 'boolean') {
+		return false;
+	}
+
+	if (obj.maxAttempts !== undefined && typeof obj.maxAttempts !== 'number') {
+		return false;
+	}
+
+	if (obj.backoffMs !== undefined && typeof obj.backoffMs !== 'number') {
+		return false;
+	}
+
+	return true;
+}
 
 /**
  * Type guard to check if a value is a HandoffResult.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export type {
 	BatchResult,
 	BatchSummary,
 	BatchTiming,
+	BatchWarning,
 } from './batch.js';
 export {
 	calculateBatchConfidence,
@@ -83,12 +84,15 @@ export type {
 	HandoffMetadata,
 	HandoffProtocol,
 	HandoffResult,
+	ReconnectPolicy,
 } from './handoff.js';
 export {
+	createHandoff,
 	getHandoffProtocol,
 	isHandoff,
 	isHandoffCommand,
 	isHandoffProtocol,
+	isReconnectPolicy,
 } from './handoff.js';
 
 // MCP types
@@ -191,6 +195,9 @@ export {
 	resolveVariable,
 	resolveVariables,
 } from './pipeline.js';
+// Pipeline executor
+export type { CommandExecutor } from './pipeline-executor.js';
+export { executePipeline } from './pipeline-executor.js';
 export type { ExecOptions, ExecResult } from './platform.js';
 // Platform utilities
 export {

--- a/packages/core/src/pipeline-executor.ts
+++ b/packages/core/src/pipeline-executor.ts
@@ -1,0 +1,242 @@
+/**
+ * @fileoverview Core pipeline execution engine
+ *
+ * Transport-agnostic pipeline executor that handles sequential step execution,
+ * variable resolution, conditional steps, error propagation, timeouts, and
+ * metadata aggregation. Server and DirectClient delegate here.
+ */
+
+import type { CommandResult } from './result.js';
+import type {
+	PipelineContext,
+	PipelineMetadata,
+	PipelineRequest,
+	PipelineResult,
+	StepResult,
+} from './pipeline.js';
+import {
+	aggregatePipelineAlternatives,
+	aggregatePipelineConfidence,
+	aggregatePipelineReasoning,
+	aggregatePipelineSources,
+	aggregatePipelineWarnings,
+	buildConfidenceBreakdown,
+	evaluateCondition,
+	resolveVariables,
+} from './pipeline.js';
+
+/**
+ * Callback type for executing a single command during pipeline execution.
+ *
+ * This abstraction allows the core executor to remain transport-agnostic —
+ * the server, DirectClient, or test harness provides its own implementation.
+ */
+export type CommandExecutor = (
+	commandName: string,
+	input: unknown,
+	context: Record<string, unknown>
+) => Promise<CommandResult>;
+
+/**
+ * Execute a pipeline of chained commands with variable resolution.
+ *
+ * This is the core pipeline execution engine. It handles:
+ * - Sequential step execution with variable resolution ($prev, $steps, etc.)
+ * - Conditional step execution via `when` clauses
+ * - Error propagation (stop on first failure or continue)
+ * - Timeout enforcement
+ * - Metadata aggregation across all steps
+ *
+ * Transport layers (server, DirectClient) delegate to this function
+ * by providing a `CommandExecutor` callback.
+ *
+ * @param request - The pipeline request with steps and options
+ * @param execute - Callback to execute a single command
+ * @param context - Optional context passed to each command execution
+ * @returns A PipelineResult with aggregated data and metadata
+ *
+ * @example
+ * ```typescript
+ * const result = await executePipeline(
+ *   {
+ *     steps: [
+ *       { command: 'user-get', input: { id: 1 }, as: 'user' },
+ *       { command: 'order-list', input: { userId: '$prev.id' } },
+ *     ],
+ *   },
+ *   async (name, input, ctx) => server.execute(name, input, ctx),
+ * );
+ * ```
+ */
+export async function executePipeline(
+	request: PipelineRequest,
+	execute: CommandExecutor,
+	context: Record<string, unknown> = {}
+): Promise<PipelineResult> {
+	const startTime = performance.now();
+	const pipelineId = request.id ?? `pipeline-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+	// Empty pipeline shortcut
+	if (!request.steps || request.steps.length === 0) {
+		return {
+			data: undefined,
+			metadata: {
+				confidence: 0,
+				confidenceBreakdown: [],
+				reasoning: [],
+				warnings: [],
+				sources: [],
+				alternatives: [],
+				executionTimeMs: 0,
+				completedSteps: 0,
+				totalSteps: 0,
+			},
+			steps: [],
+		};
+	}
+
+	const pipelineContext: PipelineContext = {
+		pipelineInput: context as Record<string, unknown>,
+		previousResult: undefined,
+		steps: [],
+	};
+
+	const stepResults: StepResult[] = [];
+	const options = request.options ?? {};
+	let stopped = false;
+
+	for (let i = 0; i < request.steps.length; i++) {
+		const step = request.steps[i];
+		if (!step) continue;
+		const stepStartTime = performance.now();
+
+		// Check if pipeline was stopped by a previous failure
+		if (stopped) {
+			stepResults.push({
+				index: i,
+				alias: step.as,
+				command: step.command,
+				status: 'skipped',
+				executionTimeMs: 0,
+			});
+			continue;
+		}
+
+		// Evaluate when condition if present
+		if (step.when && !evaluateCondition(step.when, pipelineContext)) {
+			stepResults.push({
+				index: i,
+				alias: step.as,
+				command: step.command,
+				status: 'skipped',
+				executionTimeMs: 0,
+			});
+			continue;
+		}
+
+		// Resolve variables in step input
+		const resolvedInput = step.input ? resolveVariables(step.input, pipelineContext) : {};
+
+		// Execute the command via the provided executor
+		const result = await execute(step.command, resolvedInput, {
+			...context,
+			traceId: (context.traceId as string | undefined) ?? `${pipelineId}-step-${i}`,
+		});
+
+		const stepExecutionTimeMs = performance.now() - stepStartTime;
+
+		if (result.success) {
+			const stepResult: StepResult = {
+				index: i,
+				alias: step.as,
+				command: step.command,
+				status: 'success',
+				data: result.data,
+				executionTimeMs: Math.round(stepExecutionTimeMs * 100) / 100,
+				metadata: {
+					confidence: result.confidence,
+					reasoning: result.reasoning,
+					warnings: result.warnings,
+					sources: result.sources,
+					alternatives: result.alternatives,
+				},
+			};
+			stepResults.push(stepResult);
+			pipelineContext.steps.push(stepResult);
+			pipelineContext.previousResult = stepResult;
+		} else {
+			const stepResult: StepResult = {
+				index: i,
+				alias: step.as,
+				command: step.command,
+				status: 'failure',
+				error: result.error,
+				executionTimeMs: Math.round(stepExecutionTimeMs * 100) / 100,
+			};
+			stepResults.push(stepResult);
+
+			if (!options.continueOnFailure) {
+				stopped = true;
+				// Mark remaining steps as skipped
+				for (let j = i + 1; j < request.steps.length; j++) {
+					const remainingStep = request.steps[j];
+					if (!remainingStep) continue;
+					stepResults.push({
+						index: j,
+						alias: remainingStep.as,
+						command: remainingStep.command,
+						status: 'skipped',
+						executionTimeMs: 0,
+					});
+				}
+				break;
+			}
+		}
+
+		// Check timeout
+		if (options.timeoutMs && performance.now() - startTime > options.timeoutMs) {
+			for (let j = i + 1; j < request.steps.length; j++) {
+				const remainingStep = request.steps[j];
+				if (!remainingStep) continue;
+				stepResults.push({
+					index: j,
+					alias: remainingStep.as,
+					command: remainingStep.command,
+					status: 'skipped',
+					error: {
+						code: 'PIPELINE_TIMEOUT',
+						message: `Pipeline timeout exceeded (${options.timeoutMs}ms)`,
+						retryable: true,
+					},
+					executionTimeMs: 0,
+				});
+			}
+			break;
+		}
+	}
+
+	const totalExecutionTimeMs = performance.now() - startTime;
+
+	// Get the last successful step's data as the pipeline output
+	const lastSuccessfulStep = [...stepResults].reverse().find((s) => s.status === 'success');
+	const finalData = lastSuccessfulStep?.data;
+
+	// Build metadata using helper functions
+	const metadata: PipelineMetadata = {
+		confidence: aggregatePipelineConfidence(stepResults),
+		confidenceBreakdown: buildConfidenceBreakdown(stepResults, request.steps),
+		reasoning: aggregatePipelineReasoning(stepResults),
+		warnings: aggregatePipelineWarnings(stepResults),
+		sources: aggregatePipelineSources(stepResults),
+		alternatives: aggregatePipelineAlternatives(stepResults),
+		executionTimeMs: Math.round(totalExecutionTimeMs * 100) / 100,
+		completedSteps: stepResults.filter((s) => s.status === 'success').length,
+		totalSteps: request.steps.length,
+	};
+
+	return {
+		data: finalData,
+		metadata,
+		steps: stepResults,
+	};
+}

--- a/packages/core/src/pipeline.test.ts
+++ b/packages/core/src/pipeline.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import type { CommandExecutor } from './pipeline-executor.js';
+import { executePipeline } from './pipeline-executor.js';
 import type {
 	PipelineCondition,
 	PipelineContext,
@@ -851,5 +853,274 @@ describe('resolveReference (backwards compatibility)', () => {
 
 		expect(resolveReference('$prev.id', context)).toBe(123);
 		expect(resolveVariable('$prev.id', context)).toBe(123);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CORE executePipeline TESTS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('executePipeline', () => {
+	/** Mock command executor that returns canned results */
+	function createMockExecutor(
+		results: Record<
+			string,
+			(input: unknown) => {
+				success: boolean;
+				data?: unknown;
+				error?: { code: string; message: string };
+				confidence?: number;
+				reasoning?: string;
+				warnings?: Array<{
+					code: string;
+					message: string;
+					severity: 'info' | 'warning' | 'caution';
+				}>;
+				sources?: Array<{ type: string; id: string }>;
+				alternatives?: Array<{ data: unknown; reason: string }>;
+			}
+		>
+	): CommandExecutor {
+		return async (commandName, input, _ctx) => {
+			const handler = results[commandName];
+			if (!handler) {
+				return {
+					success: false,
+					error: { code: 'COMMAND_NOT_FOUND', message: `Unknown command: ${commandName}` },
+				};
+			}
+			return handler(input);
+		};
+	}
+
+	it('returns empty result for empty steps', async () => {
+		const executor = createMockExecutor({});
+		const result = await executePipeline({ steps: [] }, executor);
+
+		expect(result.steps).toHaveLength(0);
+		expect(result.metadata.totalSteps).toBe(0);
+		expect(result.metadata.completedSteps).toBe(0);
+		expect(result.metadata.confidence).toBe(0);
+	});
+
+	it('executes a single step', async () => {
+		const executor = createMockExecutor({
+			'user-get': () => ({
+				success: true,
+				data: { id: 1, name: 'Alice' },
+				confidence: 0.95,
+			}),
+		});
+
+		const result = await executePipeline(
+			{ steps: [{ command: 'user-get', input: { id: 1 } }] },
+			executor
+		);
+
+		expect(result.data).toEqual({ id: 1, name: 'Alice' });
+		expect(result.steps).toHaveLength(1);
+		expect(result.steps[0]?.status).toBe('success');
+		expect(result.metadata.completedSteps).toBe(1);
+		expect(result.metadata.totalSteps).toBe(1);
+		expect(result.metadata.confidence).toBe(0.95);
+	});
+
+	it('chains steps with $prev variable resolution', async () => {
+		const executor = createMockExecutor({
+			'user-get': () => ({
+				success: true,
+				data: { id: 1, name: 'Alice' },
+				confidence: 0.95,
+			}),
+			'order-list': (input) => ({
+				success: true,
+				data: { orders: [{ userId: (input as { userId: number }).userId }] },
+				confidence: 0.9,
+			}),
+		});
+
+		const result = await executePipeline(
+			{
+				steps: [
+					{ command: 'user-get', input: { id: 1 } },
+					{ command: 'order-list', input: { userId: '$prev.id' } },
+				],
+			},
+			executor
+		);
+
+		expect(result.steps).toHaveLength(2);
+		expect(result.steps[1]?.status).toBe('success');
+		expect(result.data).toEqual({ orders: [{ userId: 1 }] });
+		expect(result.metadata.confidence).toBe(0.9); // weakest link
+	});
+
+	it('supports aliased steps with $steps.alias', async () => {
+		const executor = createMockExecutor({
+			'user-get': () => ({
+				success: true,
+				data: { id: 1, name: 'Alice' },
+				confidence: 0.95,
+			}),
+			'order-list': () => ({
+				success: true,
+				data: { total: 5 },
+				confidence: 0.9,
+			}),
+			'order-summarize': (input) => ({
+				success: true,
+				data: {
+					summary: `${(input as { userName: string }).userName}: ${(input as { orderTotal: number }).orderTotal} orders`,
+				},
+				confidence: 0.85,
+			}),
+		});
+
+		const result = await executePipeline(
+			{
+				steps: [
+					{ command: 'user-get', input: { id: 1 }, as: 'user' },
+					{ command: 'order-list', input: { userId: '$prev.id' }, as: 'orders' },
+					{
+						command: 'order-summarize',
+						input: {
+							userName: '$steps.user.name',
+							orderTotal: '$steps.orders.total',
+						},
+					},
+				],
+			},
+			executor
+		);
+
+		expect(result.steps).toHaveLength(3);
+		expect(result.data).toEqual({ summary: 'Alice: 5 orders' });
+	});
+
+	it('skips steps when condition is false', async () => {
+		const executor = createMockExecutor({
+			'user-get': () => ({
+				success: true,
+				data: { id: 1, tier: 'standard' },
+				confidence: 0.95,
+			}),
+			'discount-apply': () => ({
+				success: true,
+				data: { discounted: true },
+				confidence: 1.0,
+			}),
+		});
+
+		const result = await executePipeline(
+			{
+				steps: [
+					{ command: 'user-get', input: { id: 1 } },
+					{
+						command: 'discount-apply',
+						input: {},
+						when: { $eq: ['$prev.tier', 'premium'] },
+					},
+				],
+			},
+			executor
+		);
+
+		expect(result.steps).toHaveLength(2);
+		expect(result.steps[1]?.status).toBe('skipped');
+		// Data should be from last successful step (user-get)
+		expect(result.data).toEqual({ id: 1, tier: 'standard' });
+	});
+
+	it('stops on first failure by default', async () => {
+		const executor = createMockExecutor({
+			'step-a': () => ({ success: true, data: 'a' }),
+			'step-b': () => ({
+				success: false,
+				error: { code: 'FAILED', message: 'Step B failed' },
+			}),
+			'step-c': () => ({ success: true, data: 'c' }),
+		});
+
+		const result = await executePipeline(
+			{
+				steps: [{ command: 'step-a' }, { command: 'step-b' }, { command: 'step-c' }],
+			},
+			executor
+		);
+
+		expect(result.steps[0]?.status).toBe('success');
+		expect(result.steps[1]?.status).toBe('failure');
+		expect(result.steps[2]?.status).toBe('skipped');
+		expect(result.metadata.completedSteps).toBe(1);
+	});
+
+	it('continues on failure when continueOnFailure is true', async () => {
+		const executor = createMockExecutor({
+			'step-a': () => ({ success: true, data: 'a' }),
+			'step-b': () => ({
+				success: false,
+				error: { code: 'FAILED', message: 'Step B failed' },
+			}),
+			'step-c': () => ({ success: true, data: 'c' }),
+		});
+
+		const result = await executePipeline(
+			{
+				steps: [{ command: 'step-a' }, { command: 'step-b' }, { command: 'step-c' }],
+				options: { continueOnFailure: true },
+			},
+			executor
+		);
+
+		expect(result.steps[0]?.status).toBe('success');
+		expect(result.steps[1]?.status).toBe('failure');
+		expect(result.steps[2]?.status).toBe('success');
+		expect(result.metadata.completedSteps).toBe(2);
+		// Final data is from last successful step
+		expect(result.data).toBe('c');
+	});
+
+	it('aggregates metadata from all steps', async () => {
+		const executor = createMockExecutor({
+			'step-a': () => ({
+				success: true,
+				data: 'a',
+				confidence: 0.9,
+				reasoning: 'Step A reasoning',
+				warnings: [{ code: 'WARN_A', message: 'Warning A', severity: 'info' as const }],
+				sources: [{ type: 'api', id: 'source-a' }],
+			}),
+			'step-b': () => ({
+				success: true,
+				data: 'b',
+				confidence: 0.8,
+				reasoning: 'Step B reasoning',
+				sources: [{ type: 'db', id: 'source-b' }],
+			}),
+		});
+
+		const result = await executePipeline(
+			{
+				steps: [{ command: 'step-a' }, { command: 'step-b' }],
+			},
+			executor
+		);
+
+		expect(result.metadata.confidence).toBe(0.8); // weakest link
+		expect(result.metadata.reasoning).toHaveLength(2);
+		expect(result.metadata.warnings).toHaveLength(1);
+		expect(result.metadata.sources).toHaveLength(2);
+		expect(result.metadata.confidenceBreakdown).toHaveLength(2);
+	});
+
+	it('produces valid PipelineResult', async () => {
+		const executor = createMockExecutor({
+			'test-cmd': () => ({ success: true, data: { ok: true }, confidence: 1.0 }),
+		});
+
+		const result = await executePipeline({ steps: [{ command: 'test-cmd' }] }, executor);
+
+		expect(isPipelineResult(result)).toBe(true);
+		expect(result.metadata.executionTimeMs).toBeGreaterThanOrEqual(0);
 	});
 });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -14,29 +14,19 @@ import type {
 	CommandContext,
 	CommandMiddleware,
 	CommandResult,
-	PipelineContext,
-	PipelineMetadata,
 	PipelineRequest,
 	PipelineResult,
-	StepResult,
 	StreamChunk,
 } from '@lushly-dev/afd-core';
 import {
-	aggregatePipelineAlternatives,
-	aggregatePipelineConfidence,
-	aggregatePipelineReasoning,
-	aggregatePipelineSources,
-	aggregatePipelineWarnings,
-	buildConfidenceBreakdown,
+	executePipeline as coreExecutePipeline,
 	createBatchResult,
 	createCompleteChunk,
 	createErrorChunk,
 	createFailedBatchResult,
-	evaluateCondition,
 	failure,
 	isBatchRequest,
 	isPipelineRequest,
-	resolveVariables,
 } from '@lushly-dev/afd-core';
 import { Server as McpSdkServer } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -489,178 +479,19 @@ export function createMcpServer(options: McpServerOptions): McpServer {
 
 	/**
 	 * Execute a pipeline of chained commands with variable resolution.
+	 *
+	 * Delegates to the core executePipeline, providing the server's
+	 * executeCommand as the command executor callback.
 	 */
 	async function executePipeline(
 		request: PipelineRequest,
 		context: CommandContext = {}
 	): Promise<PipelineResult> {
-		const startTime = performance.now();
-		const pipelineId =
-			request.id ?? `pipeline-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-
-		// Validate request
-		if (!request.steps || request.steps.length === 0) {
-			return {
-				data: undefined,
-				metadata: {
-					confidence: 0,
-					confidenceBreakdown: [],
-					reasoning: [],
-					warnings: [],
-					sources: [],
-					alternatives: [],
-					executionTimeMs: 0,
-					completedSteps: 0,
-					totalSteps: 0,
-				},
-				steps: [],
-			};
-		}
-
-		const pipelineContext: PipelineContext = {
-			pipelineInput: context as Record<string, unknown>,
-			previousResult: undefined,
-			steps: [],
-		};
-
-		const stepResults: StepResult[] = [];
-		const options = request.options ?? {};
-		let stopped = false;
-
-		for (let i = 0; i < request.steps.length; i++) {
-			const step = request.steps[i];
-			if (!step) continue;
-			const stepStartTime = performance.now();
-
-			// Check if pipeline was stopped by a previous failure
-			if (stopped) {
-				stepResults.push({
-					index: i,
-					alias: step.as,
-					command: step.command,
-					status: 'skipped',
-					executionTimeMs: 0,
-				});
-				continue;
-			}
-
-			// Evaluate when condition if present
-			if (step.when && !evaluateCondition(step.when, pipelineContext)) {
-				stepResults.push({
-					index: i,
-					alias: step.as,
-					command: step.command,
-					status: 'skipped',
-					executionTimeMs: 0,
-				});
-				continue;
-			}
-
-			// Resolve variables in step input
-			const resolvedInput = step.input ? resolveVariables(step.input, pipelineContext) : {};
-
-			// Execute the command
-			const result = await executeCommand(step.command, resolvedInput, {
-				...context,
-				traceId: context.traceId ?? `${pipelineId}-step-${i}`,
-			});
-
-			const stepExecutionTimeMs = performance.now() - stepStartTime;
-
-			if (result.success) {
-				const stepResult: StepResult = {
-					index: i,
-					alias: step.as,
-					command: step.command,
-					status: 'success',
-					data: result.data,
-					executionTimeMs: Math.round(stepExecutionTimeMs * 100) / 100,
-					metadata: {
-						confidence: result.confidence,
-						reasoning: result.reasoning,
-						warnings: result.warnings,
-						sources: result.sources,
-						alternatives: result.alternatives,
-					},
-				};
-				stepResults.push(stepResult);
-				pipelineContext.steps.push(stepResult);
-				pipelineContext.previousResult = stepResult;
-			} else {
-				const stepResult: StepResult = {
-					index: i,
-					alias: step.as,
-					command: step.command,
-					status: 'failure',
-					error: result.error,
-					executionTimeMs: Math.round(stepExecutionTimeMs * 100) / 100,
-				};
-				stepResults.push(stepResult);
-
-				if (!options.continueOnFailure) {
-					stopped = true;
-					// Mark remaining steps as skipped
-					for (let j = i + 1; j < request.steps.length; j++) {
-						const remainingStep = request.steps[j];
-						if (!remainingStep) continue;
-						stepResults.push({
-							index: j,
-							alias: remainingStep.as,
-							command: remainingStep.command,
-							status: 'skipped',
-							executionTimeMs: 0,
-						});
-					}
-					break;
-				}
-			}
-
-			// Check timeout
-			if (options.timeoutMs && performance.now() - startTime > options.timeoutMs) {
-				for (let j = i + 1; j < request.steps.length; j++) {
-					const remainingStep = request.steps[j];
-					if (!remainingStep) continue;
-					stepResults.push({
-						index: j,
-						alias: remainingStep.as,
-						command: remainingStep.command,
-						status: 'skipped',
-						error: {
-							code: 'PIPELINE_TIMEOUT',
-							message: `Pipeline timeout exceeded (${options.timeoutMs}ms)`,
-							retryable: true,
-						},
-						executionTimeMs: 0,
-					});
-				}
-				break;
-			}
-		}
-
-		const totalExecutionTimeMs = performance.now() - startTime;
-
-		// Get the last successful step's data as the pipeline output
-		const lastSuccessfulStep = [...stepResults].reverse().find((s) => s.status === 'success');
-		const finalData = lastSuccessfulStep?.data;
-
-		// Build metadata using helper functions
-		const metadata: PipelineMetadata = {
-			confidence: aggregatePipelineConfidence(stepResults),
-			confidenceBreakdown: buildConfidenceBreakdown(stepResults, request.steps),
-			reasoning: aggregatePipelineReasoning(stepResults),
-			warnings: aggregatePipelineWarnings(stepResults),
-			sources: aggregatePipelineSources(stepResults),
-			alternatives: aggregatePipelineAlternatives(stepResults),
-			executionTimeMs: Math.round(totalExecutionTimeMs * 100) / 100,
-			completedSteps: stepResults.filter((s) => s.status === 'success').length,
-			totalSteps: request.steps.length,
-		};
-
-		return {
-			data: finalData,
-			metadata,
-			steps: stepResults,
-		};
+		return coreExecutePipeline(
+			request,
+			(commandName, input, ctx) => executeCommand(commandName, input, ctx as CommandContext),
+			context as Record<string, unknown>
+		);
 	}
 
 	/**


### PR DESCRIPTION
TypeScript core parity — extracted and added four additive features:

- ReconnectPolicy: Named type extracted from HandoffMetadata inline object,
  with isReconnectPolicy() type guard for validation
- createHandoff(): Convenience factory with sensible defaults (pass
  `reconnect: true` for default policy, or provide custom ReconnectPolicy)
- BatchWarning: Named type for batch result warnings, replacing the
  inline anonymous object shape in BatchResult.warnings
- executePipeline(): Core-level pipeline executor in pipeline-executor.ts
  with CommandExecutor callback abstraction. Server now delegates to core
  (net -169 lines from server.ts). Pipeline types remain in pipeline.ts.

All additions are backward-compatible. Existing tests pass unchanged.
New regression tests cover all four additions (400 core tests pass).

Closes #151

https://claude.ai/code/session_01S2yNPk2bK7EhVA3HBP9xMw