### PR TITLE
docs: view-state pattern plan

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -15,6 +15,7 @@ Feature specifications organized by lifecycle stage.
 | Feature | Description | Status |
 |---------|-------------|--------|
 | [Output Shape Predictability](./active/output-shape-predictability/) | Consistent output schemas for agent consumption | In Progress |
+| [View State](./active/view-state/) | Unified UI view state management via commands | Planned |
 
 ## Complete Features
 

--- a/docs/features/active/view-state/view-state.proposal.md
+++ b/docs/features/active/view-state/view-state.proposal.md
@@ -1,7 +1,10 @@
 ---
-Status: Planned
-Date: 2026-03-01
-Depends on: ["@lushly-dev/local-db"]
+status: planned
+created: 2026-03-01
+origin: fabric-ux-prototype — UI view state managed outside the command system, invisible to agents and tests
+effort: S (1-2 days for Option A docs, M 3-5 days for Option B package)
+package: "@lushly-dev/afd-view-state"
+depends-on: "@lushly-dev/local-db"
 ---
 
 # View State — AFD Command Pattern for UI State Management


### PR DESCRIPTION
Plan doc for a new AFD pattern: unified UI view state management via commands.

Reference implementation validated in fabric-ux-prototype. See \docs/features/active/view-state.plan.md\ for the full design.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>