### PR TITLE
Complete Rust export parity

### DIFF
--- a/.claude/skills/afd-rust/SKILL.md
+++ b/.claude/skills/afd-rust/SKILL.md
@@ -34,7 +34,8 @@ use afd::{
 // Command types
 use afd::{
     CommandDefinition, CommandParameter, CommandContext,
-    CommandHandler, CommandRegistry,
+    CommandExample, CommandHandler, CommandRegistry,
+    ExposeOptions, default_expose, validate_command_name,
     JsonSchema, JsonSchemaType,
 };
 
@@ -47,7 +48,16 @@ use afd::{
 // Batch and streaming
 use afd::{
     BatchRequest, BatchResult, BatchCommand,
-    StreamChunk, create_progress_chunk, create_data_chunk,
+    StreamChunk, StreamableCommand,
+    create_progress_chunk, create_data_chunk,
+    create_complete_chunk, create_error_chunk,
+};
+
+// Additional parity helpers
+use afd::{
+    create_handoff, create_mcp_request, create_mcp_response,
+    create_telemetry_event, execute_pipeline,
+    calculate_similarity, find_similar_tools,
 };
 ```
 
@@ -109,8 +119,7 @@ fn create_user(email: &str) -> CommandResult<User> {
         return failure(CommandError::new(
             "CONFLICT",
             format!("Email '{}' already registered", email),
-            Some("Use user-login instead, or reset password"),
-        ));
+        ).with_suggestion("Use user-login instead, or reset password"));
     }
     // ... create user
 }
@@ -150,8 +159,7 @@ let err = CommandError::internal("Database connection failed");
 let err = CommandError::new(
     "RATE_LIMITED",
     "Too many requests",
-    Some("Wait 60 seconds before retrying"),
-);
+).with_suggestion("Wait 60 seconds before retrying");
 
 // With retryable flag
 let err = CommandError {
@@ -170,7 +178,9 @@ let err = CommandError {
 
 ```rust
 use async_trait::async_trait;
-use afd::{CommandHandler, CommandContext, CommandResult, success};
+use std::sync::Arc;
+
+use afd::{CommandContext, CommandError, CommandHandler, CommandResult, failure, success};
 use serde_json::Value;
 
 struct CreateTodoHandler {
@@ -184,9 +194,11 @@ impl CommandHandler for CreateTodoHandler {
         input: Value,
         _context: CommandContext,
     ) -> CommandResult<Value> {
-        // Parse input
-        let title = input["title"].as_str()
-            .ok_or_else(|| CommandError::validation("title is required", None))?;
+        // Parse input at the command boundary and return a CommandResult on failure.
+        let title = match input.get("title").and_then(|value| value.as_str()) {
+            Some(title) => title,
+            None => return failure(CommandError::validation("title is required", None)),
+        };
 
         // Execute logic
         let todo = self.store.create(title).await;
@@ -256,15 +268,17 @@ let param = CommandParameter::required_string("priority", "Priority level")
 ## Command Registry
 
 ```rust
-use afd::{CommandRegistry, CommandDefinition};
+use afd::{CommandDefinition, CommandRegistry, validate_command_name};
 
 // Create registry
 let mut registry = CommandRegistry::new();
 
 // Register commands
-registry.register(create_todo_cmd)?;
-registry.register(list_todos_cmd)?;
-registry.register(get_todo_cmd)?;
+registry.register(create_todo_cmd).expect("valid command definition");
+registry.register(list_todos_cmd).expect("valid command definition");
+registry.register(get_todo_cmd).expect("valid command definition");
+
+validate_command_name("todo-create").expect("valid command name");
 
 // Check if command exists
 if registry.has("todo-create") {
@@ -292,21 +306,15 @@ use afd::{BatchRequest, BatchCommand, BatchOptions};
 // Create batch request
 let request = BatchRequest {
     commands: vec![
-        BatchCommand {
-            id: Some("1".to_string()),
-            command: "todo-create".to_string(),
-            input: serde_json::json!({"title": "First"}),
-        },
-        BatchCommand {
-            id: Some("2".to_string()),
-            command: "todo-create".to_string(),
-            input: serde_json::json!({"title": "Second"}),
-        },
+        BatchCommand::new("1", "todo-create", serde_json::json!({"title": "First"})),
+        BatchCommand::new("2", "todo-create", serde_json::json!({"title": "Second"})),
     ],
     options: BatchOptions {
         continue_on_error: true,
-        max_concurrent: Some(4),
+        max_concurrency: Some(4),
+        ..Default::default()
     },
+    context: None,
 };
 
 // Execute batch
@@ -323,6 +331,7 @@ use afd::{
     StreamChunk, create_progress_chunk, create_data_chunk,
     create_complete_chunk, create_error_chunk,
 };
+use afd::CommandError;
 
 // Progress update
 let progress = create_progress_chunk(50.0, "Processing items...");
@@ -334,26 +343,36 @@ let data = create_data_chunk(partial_result, false);
 let final_data = create_data_chunk(complete_result, true);
 
 // Completion
-let complete = create_complete_chunk(final_result);
+let complete = create_complete_chunk(final_result, Some(1500));
 
 // Error during streaming
-let error = create_error_chunk(CommandError::internal("Stream interrupted"));
+let error = create_error_chunk(CommandError::internal("Stream interrupted"), false);
 ```
 
 ## Metadata Types
+
+## Current Parity Note
+
+The Rust crate now includes parity helpers for:
+
+- command ergonomics: `CommandExample`, `ExposeOptions`, `default_expose`, `validate_command_name`
+- streaming: `StreamableCommand`, `consume_stream`, `create_timeout_controller`
+- handoff and telemetry: `create_handoff`, `default_reconnect_policy`, `TelemetryEvent`
+- MCP and pipelines: `create_mcp_request`, `create_mcp_response`, `execute_pipeline`
+- discovery helpers: `calculate_similarity`, `find_similar_tools`
 
 ### Warnings
 
 ```rust
 use afd::{Warning, WarningSeverity, create_warning};
 
-let warning = create_warning("DEPRECATION", "This field is deprecated");
+let warning = create_warning("DEPRECATION", "This field is deprecated", None);
 
 let warning = Warning {
     code: "PERMANENT".to_string(),
     message: "This action cannot be undone".to_string(),
     severity: Some(WarningSeverity::High),
-    field: None,
+    context: None,
 };
 ```
 
@@ -362,13 +381,15 @@ let warning = Warning {
 ```rust
 use afd::{Source, SourceType, create_source};
 
-let source = create_source("API Response", SourceType::Api);
+let source = create_source("API Response", SourceType::Api, None);
 
 let source = Source {
     name: "User Database".to_string(),
     source_type: SourceType::Database,
     url: Some("postgres://...".to_string()),
-    confidence: Some(0.99),
+    accessed_at: None,
+    relevance: Some(0.99),
+    snippet: None,
 };
 ```
 
@@ -377,11 +398,11 @@ let source = Source {
 ```rust
 use afd::{PlanStep, PlanStepStatus, create_step, update_step_status};
 
-let step = create_step(1, "Validate input");
+let step = create_step(1, "Validate input", PlanStepStatus::Pending);
 
 let mut step = PlanStep::new(1, "Process data");
-step = update_step_status(step, PlanStepStatus::InProgress);
-step = update_step_status(step, PlanStepStatus::Completed);
+update_step_status(&mut step, PlanStepStatus::Running, None, None);
+update_step_status(&mut step, PlanStepStatus::Completed, Some(120), None);
 ```
 
 ## JSON Serialization
@@ -412,13 +433,26 @@ fn process_result<T>(result: &CommandResult<T>) {
 
 ## Error Handling Patterns
 
-### Using Result with ?
+### Using Result Internally
+
+Use `Result<T, CommandError>` inside helpers, then convert to `CommandResult<T>` at the command boundary.
 
 ```rust
+use afd::{failure, success_with, CommandError, CommandResult, ResultOptions};
+use serde_json::Value;
+
+fn parse_title(input: &Value) -> Result<&str, CommandError> {
+    input
+        .get("title")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| CommandError::validation("title is required", None))
+}
+
 async fn create_todo(input: Value, store: &TodoStore) -> CommandResult<Todo> {
-    // Parse required field
-    let title = input["title"].as_str()
-        .ok_or_else(|| CommandError::validation("title is required", None))?;
+    let title = match parse_title(&input) {
+        Ok(title) => title,
+        Err(error) => return failure(error),
+    };
 
     // Validate
     if title.is_empty() {
@@ -429,8 +463,10 @@ async fn create_todo(input: Value, store: &TodoStore) -> CommandResult<Todo> {
     }
 
     // Execute with error conversion
-    let todo = store.create(title).await
-        .map_err(|e| CommandError::internal(&e.to_string()))?;
+    let todo = match store.create(title).await {
+        Ok(todo) => todo,
+        Err(error) => return failure(CommandError::internal(&error.to_string())),
+    };
 
     success_with(todo, ResultOptions {
         reasoning: Some(format!("Created todo '{}'", title)),
@@ -442,15 +478,23 @@ async fn create_todo(input: Value, store: &TodoStore) -> CommandResult<Todo> {
 ### Wrapping External Errors
 
 ```rust
+use afd::{failure, success, CommandError, CommandResult};
+
 impl From<sqlx::Error> for CommandError {
     fn from(err: sqlx::Error) -> Self {
         CommandError::internal(&format!("Database error: {}", err))
     }
 }
 
+async fn load_user(id: &str) -> Result<User, CommandError> {
+    db.get_user(id).await.map_err(CommandError::from)
+}
+
 async fn get_user(id: &str) -> CommandResult<User> {
-    let user = db.get_user(id).await?;  // Converts sqlx::Error
-    success(user)
+    match load_user(id).await {
+        Ok(user) => success(user),
+        Err(error) => failure(error),
+    }
 }
 ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ Cargo.lock
 *.plan.md
 !PLAN/**/*.plan.md
 !archive/**/*.plan.md
+!docs/features/active/**/*.plan.md
 .claude/worktrees/
 .cursor/
 nul

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -10,11 +10,18 @@ Feature specifications organized by lifecycle stage.
 | [active/](./active/) | Approved features in implementation |
 | [complete/](./complete/) | Shipped features (reference archive) |
 
+## Active Features
+
+| Feature | Description |
+|---------|-------------|
+| [Rust Parity Closure](./active/rust-parity/) | Close the export-surface gap between TypeScript and Rust using `alfred parity` as the tracking source |
+
 ## Complete Features
 
 | Feature | Description |
 |---------|-------------|
 | [AFD Bot (Alfred)](./complete/afd-bot/) | Deterministic repo quality agent with lint, parity, and quality commands |
+| [AFD PyPI Publishing](./complete/afd-pypi-publishing/) | Python package publishing to PyPI |
 | [Auth Adapter](./complete/auth-adapter/) | Provider-agnostic authentication adapter for AFD servers |
 | [Command Prerequisites](./complete/command-prerequisites/) | Declarative `requires` field for planning-order dependencies |
 | [Contextual Tool Loading](./complete/contextual-tool-loading/) | Dynamic context scoping for large command sets |
@@ -34,7 +41,6 @@ Feature specifications organized by lifecycle stage.
 
 | Feature | Description |
 |---------|-------------|
-| [AFD PyPI Publishing](./proposed/afd-pypi-publishing/) | Python package publishing to PyPI |
 | [Chat History Panel](./proposed/chat-history-panel/) | Chat history UI component |
 | [Code Client](./proposed/code-client/) | Code-based client research |
 | [Design to Code](./proposed/design-to-code/) | Figma-to-code generation pipeline |

--- a/docs/features/active/rust-parity/rust-parity.plan.md
+++ b/docs/features/active/rust-parity/rust-parity.plan.md
@@ -1,0 +1,315 @@
+# Rust Parity Closure Plan
+
+## Overview
+
+The Rust AFD crate already covers the core result model, batch primitives, streaming basics, pipelines, bootstrap helpers, and handoff metadata, but it still lags the TypeScript barrel export surface in meaningful ways.
+
+As of March 21, 2026, the canonical parity check is:
+
+```bash
+uv run --project alfred alfred parity --path .
+```
+
+That command currently reports:
+
+- `typescript`: 183 exports
+- `python`: 170 exports
+- `rust`: 130 exports
+- `missing_from_rust`: 78 exports
+
+This plan tracks the Rust-side closure work only. TypeScript remains the source of truth for parity, and Python drift is out of scope except where it clarifies intended AFD behavior.
+
+## Status
+
+| Field | Value |
+|---|---|
+| Status | Active |
+| Author | jasfalk |
+| Updated | 2026-03-21 |
+| Package | `packages/rust` |
+| Source Of Truth | `uv run --project alfred alfred parity --path .` |
+| Depends On | Existing Rust crate foundation in `docs/features/proposed/rust-support/` |
+
+## Problem
+
+Rust currently exposes only part of the AFD public surface expected by the TypeScript core package. The gaps are not cosmetic:
+
+- core command ergonomics are missing (`ExposeOptions`, `defaultExpose`, `CommandExample`, `CommandMiddleware`, `validateCommandName`)
+- the MCP type and helper layer is substantially incomplete
+- pipeline condition types and executor-facing exports are incomplete
+- telemetry, similarity, connector, and streaming helpers are missing
+- some TypeScript helper constructors are missing even where Rust has adjacent functionality
+
+This creates three problems:
+
+1. the Rust implementation is harder to use consistently across examples and docs
+2. the public API story drifts across languages even when concepts are shared
+3. parity regressions are easy to miss because the missing areas are spread across multiple modules
+
+## Current Reality
+
+The official parity command currently reports these Rust gap clusters:
+
+- `24` MCP exports missing
+- `24` pipeline exports missing
+- `8` connector exports missing
+- `5` command/core helper exports missing
+- `4` handoff exports missing
+- `4` streaming exports missing
+- `4` telemetry exports missing
+- `3` error exports missing
+- `2` similarity exports missing
+- `1` batch export missing
+
+The current Rust crate layout relevant to this work is:
+
+- `packages/rust/src/commands.rs`
+- `packages/rust/src/errors.rs`
+- `packages/rust/src/handoff.rs`
+- `packages/rust/src/pipeline.rs`
+- `packages/rust/src/streaming.rs`
+- `packages/rust/src/batch.rs`
+- `packages/rust/src/lib.rs`
+
+## Scope
+
+### In Scope
+
+- close the `missing_from_rust` list reported by `alfred parity`
+- add missing public Rust types and helper functions where TypeScript already defines the public contract
+- update `packages/rust/src/lib.rs` re-exports to match the intended public surface
+- add or extend Rust tests for newly exposed behavior
+- keep docs honest about any intentionally deferred items
+
+### Out of Scope
+
+- closing `missing_from_python`
+- removing Rust-only exports from `extra_in_rust` unless they clearly conflict with the public API direction
+- implementing Python-only or platform-only utilities that are not part of the TypeScript source-of-truth barrel
+- private Mint distribution work
+
+## Principles
+
+- parity means behavior, not just names; do not add placeholder exports with no meaningful implementation
+- TypeScript is the contract source, but Rust should stay idiomatic where implementation details differ
+- prefer finishing one module family cleanly over scattering tiny partial fixes across the crate
+- each wave should leave `lib.rs` and tests in a coherent state
+
+## Workstreams
+
+### Wave 1: Core Ergonomics And Low-Risk Helpers
+
+Goal: close the smallest, highest-leverage missing exports first.
+
+Target areas:
+
+- `commands.rs`
+  - `CommandExample`
+  - `CommandMiddleware`
+  - `ExposeOptions`
+  - `defaultExpose`
+  - `validateCommandName`
+- `errors.rs`
+  - `error`
+  - `ErrorCode`
+  - `wrapError` equivalent
+- `batch.rs`
+  - `BatchWarning`
+- `streaming.rs`
+  - `StreamableCommand`
+  - `isStreamableCommand`
+  - `consumeStream`
+  - `createTimeoutController` or an honest Rust equivalent
+- `lib.rs`
+  - export alignment for all of the above
+
+Why first:
+
+- small blast radius
+- improves everyday API ergonomics
+- creates patterns for later parity additions
+
+### Wave 2: Telemetry And Handoff Helper Completion
+
+Goal: finish the missing support surfaces around trust signals and protocol transitions.
+
+Target areas:
+
+- `telemetry.rs` or equivalent new module if needed
+  - `TelemetryEvent`
+  - `TelemetrySink`
+  - `createTelemetryEvent`
+  - `isTelemetryEvent`
+- `handoff.rs`
+  - `createHandoff`
+  - `CreateHandoffOptions`
+  - `defaultReconnectPolicy`
+  - `isReconnectPolicy`
+
+Why second:
+
+- these are well-bounded features with clear TypeScript precedents
+- they unblock richer examples and downstream parity stories without requiring the full MCP stack rewrite first
+
+### Wave 3: MCP Surface Parity
+
+Goal: close the full protocol-type gap in one coherent pass.
+
+Target areas:
+
+- request/response helpers
+  - `createMcpRequest`
+  - `createMcpResponse`
+  - `createMcpErrorResponse`
+- protocol guards
+  - `isMcpRequest`
+  - `isMcpResponse`
+  - `isMcpNotification`
+- public types
+  - `McpClientCapabilities`
+  - `McpContent`
+  - `McpError`
+  - `McpErrorCode`
+  - `McpImageContent`
+  - `McpInitializeParams`
+  - `McpInitializeResult`
+  - `McpNotification`
+  - `McpRequest`
+  - `McpResourceContent`
+  - `McpResponse`
+  - `McpServerCapabilities`
+  - `McpTextContent`
+  - `McpToolCallParams`
+  - `McpToolCallResult`
+  - `McpToolsListResult`
+  - `textContent`
+  - `McpErrorCodes`
+
+Why this is its own wave:
+
+- the missing items form a protocol family
+- consistency matters more here than piecemeal export closure
+- this work likely touches serialization, validation, and docs together
+
+### Wave 4: Pipeline Surface Parity
+
+Goal: align Rust with the TypeScript pipeline contract, including conditions and executor helpers.
+
+Target areas:
+
+- `PipelineConditionAnd`
+- `PipelineConditionEq`
+- `PipelineConditionExists`
+- `PipelineConditionGt`
+- `PipelineConditionGte`
+- `PipelineConditionLt`
+- `PipelineConditionLte`
+- `PipelineConditionNe`
+- `PipelineConditionNot`
+- `PipelineConditionOr`
+- `isAndCondition`
+- `isEqCondition`
+- `isExistsCondition`
+- `isGtCondition`
+- `isGteCondition`
+- `isLtCondition`
+- `isLteCondition`
+- `isNeCondition`
+- `isNotCondition`
+- `isOrCondition`
+- `isPipelineCondition`
+- `CommandExecutor`
+- `executePipeline`
+- `resolveReference`
+
+Why this is a separate wave:
+
+- pipeline parity affects execution semantics, not just typing
+- this is one of the largest remaining clusters
+- it deserves focused tests instead of being mixed into protocol work
+
+### Wave 5: Connector And Similarity Completion
+
+Goal: finish the remaining ecosystem-facing helpers.
+
+Target areas:
+
+- connector types
+  - `GitHubConnectorOptions`
+  - `Issue`
+  - `IssueCreateOptions`
+  - `IssueFilters`
+  - `PackageManager`
+  - `PackageManagerConnectorOptions`
+  - `PrCreateOptions`
+  - `PullRequest`
+- similarity helpers
+  - `calculateSimilarity`
+  - `findSimilarTools`
+
+Why last:
+
+- important for breadth, but not required to make the Rust core feel structurally complete
+- easier to slot in once the protocol and pipeline foundations are settled
+
+## Testing Strategy
+
+Each wave should include:
+
+- targeted Rust unit tests in `packages/rust`
+- serialization tests for shared public types where relevant
+- one parity check run before merge:
+
+```bash
+uv run --project alfred alfred parity --path .
+```
+
+Recommended checkpoint commands:
+
+```bash
+cargo test
+uv run --project alfred alfred parity --path .
+```
+
+## Acceptance Criteria
+
+- `missing_from_rust` is reduced to zero, or any remaining entries are explicitly documented as intentionally non-parity items with a reason
+- `packages/rust/src/lib.rs` reflects the intended public AFD Rust surface cleanly
+- newly exported items have real implementations or well-tested Rust-native equivalents
+- the parity command is used as the final verification gate for each wave
+
+## Open Questions
+
+### 1. MCP Module Shape
+
+The Rust crate currently re-exports several MCP-adjacent command types from `commands.rs`, but the missing MCP surface suggests a dedicated `mcp.rs` module may now be cleaner.
+
+Recommendation:
+
+- allow a new Rust module split if it reduces confusion and makes parity easier to maintain
+
+### 2. Timeout Controller Semantics
+
+`createTimeoutController` is a JavaScript-shaped helper. Rust may need an equivalent with a different internal design.
+
+Recommendation:
+
+- match the public intent, not the JS implementation detail
+- document the Rust-native timeout model if naming must stay aligned
+
+### 3. Connector Depth
+
+Some connector items may be type-only parity shims if the full runtime integration is not yet in scope.
+
+Recommendation:
+
+- add shared public types first
+- only add runtime connector behavior when the Rust crate is ready to support it honestly
+
+## Follow-On Work
+
+Once this plan is complete, reassess:
+
+- whether `docs/features/proposed/rust-support/` should move from proposed to complete
+- whether `alfred parity` should gain a narrower Rust-only mode or machine-readable wave summaries
+- whether parity should become part of regular Rust CI for the crate

--- a/docs/features/complete/afd-pypi-publishing/afd-pypi-publishing.proposal.md
+++ b/docs/features/complete/afd-pypi-publishing/afd-pypi-publishing.proposal.md
@@ -1,8 +1,12 @@
 # AFD Python Package - PyPI Publishing
 
-Status: Proposed  
+Status: Complete  
 Created: 2026-01-13  
-Updated: 2026-02-24
+Updated: 2026-03-20
+
+## Outcome
+
+Completed. The Python package is published as `afd`, the repo contains a dedicated PyPI publish workflow in `.github/workflows/publish-python.yml`, and the Python README documents `pip install afd`.
 
 ## Summary
 
@@ -28,7 +32,7 @@ Out of scope:
 - The package MUST build reproducibly from `python/` using standard Python build tooling.
 - The package MUST publish to PyPI under an approved name.
 - The package MUST include typing metadata and pass import smoke tests after install.
-- Release workflow SHOULD support token-based publish in CI.
+- Release workflow SHOULD support non-interactive CI publish via PyPI trusted publishing.
 - Documentation SHOULD include installation and version pinning guidance.
 
 ## Architecture / Dataflow
@@ -43,14 +47,14 @@ Out of scope:
 - Name unavailable on PyPI: choose fallback package name and document mapping.
 - Publish failure after build: keep artifacts, do not retag release, retry publish only.
 - Broken release detected post-publish: yank the release and publish patch increment.
-- Credential leakage risk: use API token only via CI secrets; never commit credentials.
+- Credential leakage risk: use PyPI trusted publishing where possible; never commit credentials.
 
 ## Acceptance Criteria
 
 - Package install succeeds in a fresh virtual environment via `pip install`.
 - Core imports succeed (`CommandResult`, server bootstrap utilities).
 - Version in package metadata matches release notes.
-- Publish can be run non-interactively in CI with token auth.
+- Publish can be run non-interactively in CI via trusted publishing.
 - README contains install, upgrade, and troubleshooting sections.
 
 ## Task Breakdown

--- a/packages/rust/src/batch.rs
+++ b/packages/rust/src/batch.rs
@@ -148,7 +148,11 @@ pub struct BatchCommandResult<T = serde_json::Value> {
 
 impl<T> BatchCommandResult<T> {
     /// Create a successful batch command result.
-    pub fn success(id: impl Into<String>, command: impl Into<String>, result: CommandResult<T>) -> Self {
+    pub fn success(
+        id: impl Into<String>,
+        command: impl Into<String>,
+        result: CommandResult<T>,
+    ) -> Self {
         Self {
             id: id.into(),
             command: command.into(),
@@ -162,6 +166,20 @@ impl<T> BatchCommandResult<T> {
         self.duration_ms = Some(duration_ms);
         self
     }
+}
+
+/// A warning surfaced from a command within a batch execution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchWarning {
+    /// ID of the command that produced this warning.
+    pub command_id: String,
+
+    /// Machine-readable warning code.
+    pub code: String,
+
+    /// Human-readable warning message.
+    pub message: String,
 }
 
 /// Summary statistics for a batch execution.
@@ -243,6 +261,10 @@ pub struct BatchResult<T = serde_json::Value> {
     /// Timing information.
     pub timing: BatchTiming,
 
+    /// Aggregated warnings surfaced by commands in the batch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<BatchWarning>>,
+
     /// Batch-level error if the batch itself failed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<CommandError>,
@@ -292,6 +314,23 @@ pub fn create_batch_result<T>(
         None
     };
 
+    let warnings: Vec<BatchWarning> = results
+        .iter()
+        .flat_map(|result| {
+            result
+                .result
+                .warnings
+                .as_ref()
+                .into_iter()
+                .flatten()
+                .map(|warning| BatchWarning {
+                    command_id: result.id.clone(),
+                    code: warning.code.clone(),
+                    message: warning.message.clone(),
+                })
+        })
+        .collect();
+
     BatchResult {
         success: failed == 0,
         results,
@@ -308,6 +347,7 @@ pub fn create_batch_result<T>(
             total_ms: Some(total_ms),
             average_ms,
         },
+        warnings: (!warnings.is_empty()).then_some(warnings),
         error: None,
     }
 }
@@ -324,6 +364,7 @@ pub fn create_failed_batch_result<T>(error: CommandError, started_at: &str) -> B
             total_ms: None,
             average_ms: None,
         },
+        warnings: None,
         error: Some(error),
     }
 }
@@ -364,7 +405,9 @@ pub fn is_batch_request<T: Serialize>(value: &T) -> bool {
 /// Check if a value is a BatchResult.
 pub fn is_batch_result<T: Serialize>(value: &T) -> bool {
     if let Ok(json) = serde_json::to_value(value) {
-        json.get("results").is_some() && json.get("summary").is_some() && json.get("timing").is_some()
+        json.get("results").is_some()
+            && json.get("summary").is_some()
+            && json.get("timing").is_some()
     } else {
         false
     }
@@ -382,7 +425,8 @@ pub fn is_batch_command<T: Serialize>(value: &T) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::result::success;
+    use crate::metadata::Warning;
+    use crate::result::{success, success_with, ResultOptions};
 
     #[test]
     fn test_batch_command_creation() {
@@ -435,6 +479,39 @@ mod tests {
     fn test_batch_summary_success_rate() {
         let summary = BatchSummary::new(10, 8, 2, 0);
         assert!((summary.success_rate() - 0.8).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_batch_warnings_are_aggregated() {
+        let warned_result = success_with(
+            "result1".to_string(),
+            ResultOptions {
+                warnings: Some(vec![Warning::new(
+                    "PARTIAL_DATA",
+                    "Some records were skipped",
+                )]),
+                ..Default::default()
+            },
+        );
+
+        let results = vec![
+            BatchCommandResult::success("1", "cmd1", warned_result),
+            BatchCommandResult::success("2", "cmd2", success::<String>("result2".to_string())),
+        ];
+
+        let batch_result = create_batch_result(
+            results,
+            "2025-01-01T00:00:00Z",
+            "2025-01-01T00:00:01Z",
+            1000,
+        );
+
+        let warnings = batch_result
+            .warnings
+            .expect("batch warnings should be present");
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].command_id, "1");
+        assert_eq!(warnings[0].code, "PARTIAL_DATA");
     }
 
     #[test]

--- a/packages/rust/src/commands.rs
+++ b/packages/rust/src/commands.rs
@@ -4,18 +4,44 @@
 //! is defined as a command with a clear schema.
 
 use async_trait::async_trait;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-use crate::batch::{
-    BatchCommandResult, BatchRequest, BatchResult, BatchSummary, BatchTiming,
-};
+use crate::batch::{BatchCommandResult, BatchRequest, BatchResult, BatchSummary, BatchTiming};
 use crate::errors::CommandError;
 use crate::handoff::HandoffCommandLike;
 use crate::result::CommandResult;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// COMMAND NAME VALIDATION
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn command_name_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(r"^[a-z][a-z0-9]*(-[a-z][a-z0-9]*)+$")
+            .expect("command name regex should be valid")
+    })
+}
+
+/// Validate that a command name follows the `domain-action` kebab-case convention.
+pub fn validate_command_name(name: &str) -> Result<(), String> {
+    if name.trim().is_empty() {
+        return Err("Command name must not be empty".to_string());
+    }
+
+    if !command_name_pattern().is_match(name) {
+        return Err(format!(
+            "Command name '{name}' must use kebab-case with at least two segments (e.g., 'domain-action')."
+        ));
+    }
+
+    Ok(())
+}
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // JSON SCHEMA TYPES
@@ -196,6 +222,65 @@ impl CommandParameter {
     }
 }
 
+/// A concrete input example for a command.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandExample<T = serde_json::Value> {
+    /// Short description of what this example demonstrates.
+    pub title: String,
+
+    /// A valid input payload.
+    pub input: T,
+}
+
+impl<T> CommandExample<T> {
+    /// Create a new command example.
+    pub fn new(title: impl Into<String>, input: T) -> Self {
+        Self {
+            title: title.into(),
+            input,
+        }
+    }
+}
+
+/// Controls which interfaces a command is exposed to.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExposeOptions {
+    #[serde(default = "default_true")]
+    pub palette: bool,
+    #[serde(default = "default_false")]
+    pub mcp: bool,
+    #[serde(default = "default_true")]
+    pub agent: bool,
+    #[serde(default = "default_false")]
+    pub cli: bool,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+const fn default_false() -> bool {
+    false
+}
+
+impl Default for ExposeOptions {
+    fn default() -> Self {
+        Self {
+            palette: true,
+            mcp: false,
+            agent: true,
+            cli: false,
+        }
+    }
+}
+
+/// Return the default command exposure configuration.
+pub fn default_expose() -> ExposeOptions {
+    ExposeOptions::default()
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // COMMAND CONTEXT
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -257,6 +342,22 @@ pub enum ExecutionTime {
 /// Type alias for async command handler function.
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+/// Deferred execution function used by command middleware.
+pub type MiddlewareNext =
+    Arc<dyn Fn() -> BoxFuture<'static, CommandResult<serde_json::Value>> + Send + Sync>;
+
+/// Middleware function type for intercepting command execution.
+pub type CommandMiddleware = Arc<
+    dyn Fn(
+            String,
+            serde_json::Value,
+            CommandContext,
+            MiddlewareNext,
+        ) -> BoxFuture<'static, CommandResult<serde_json::Value>>
+        + Send
+        + Sync,
+>;
+
 /// Trait for command handlers.
 #[async_trait]
 pub trait CommandHandler: Send + Sync {
@@ -308,6 +409,12 @@ pub struct CommandDefinition {
 
     /// Estimated execution time.
     pub execution_time: Option<ExecutionTime>,
+
+    /// Which interfaces this command is exposed to.
+    pub expose: ExposeOptions,
+
+    /// Concrete input examples to help agents construct valid payloads.
+    pub examples: Option<Vec<CommandExample>>,
 }
 
 impl CommandDefinition {
@@ -332,6 +439,8 @@ impl CommandDefinition {
             tags: None,
             mutation: false,
             execution_time: None,
+            expose: default_expose(),
+            examples: None,
         }
     }
 
@@ -368,6 +477,18 @@ impl CommandDefinition {
     /// Set the version for this command.
     pub fn with_version(mut self, version: impl Into<String>) -> Self {
         self.version = Some(version.into());
+        self
+    }
+
+    /// Set the command exposure configuration.
+    pub fn with_expose(mut self, expose: ExposeOptions) -> Self {
+        self.expose = expose;
+        self
+    }
+
+    /// Set concrete command examples.
+    pub fn with_examples(mut self, examples: Vec<CommandExample>) -> Self {
+        self.examples = Some(examples);
         self
     }
 
@@ -430,10 +551,13 @@ impl CommandRegistry {
     /// # Errors
     /// Returns an error if a command with the same name already exists.
     pub fn register(&mut self, command: CommandDefinition) -> Result<(), String> {
+        validate_command_name(&command.name)?;
+
         if self.commands.contains_key(&command.name) {
             return Err(format!("Command '{}' is already registered", command.name));
         }
-        self.commands.insert(command.name.clone(), Arc::new(command));
+        self.commands
+            .insert(command.name.clone(), Arc::new(command));
         Ok(())
     }
 
@@ -525,6 +649,7 @@ impl CommandRegistry {
                     total_ms: Some(0),
                     average_ms: None,
                 },
+                warnings: None,
                 error: Some(CommandError {
                     code: "INVALID_BATCH_REQUEST".to_string(),
                     message: "Batch request must contain at least one command".to_string(),
@@ -608,6 +733,7 @@ impl CommandRegistry {
                     None
                 },
             },
+            warnings: None,
             error: None,
         }
     }
@@ -701,7 +827,10 @@ mod tests {
         let cmd = CommandDefinition::new(
             "test-echo",
             "Echoes input back",
-            vec![CommandParameter::required_string("message", "Message to echo")],
+            vec![CommandParameter::required_string(
+                "message",
+                "Message to echo",
+            )],
             TestHandler,
         );
 
@@ -715,11 +844,29 @@ mod tests {
         assert!(result.success);
     }
 
+    #[test]
+    fn test_validate_command_name() {
+        assert!(validate_command_name("todo-create").is_ok());
+        assert!(validate_command_name("create").is_err());
+        assert!(validate_command_name("TodoCreate").is_err());
+    }
+
+    #[test]
+    fn test_default_expose_values() {
+        let expose = default_expose();
+        assert!(expose.palette);
+        assert!(expose.agent);
+        assert!(!expose.mcp);
+        assert!(!expose.cli);
+    }
+
     #[tokio::test]
     async fn test_command_not_found() {
         let registry = CommandRegistry::new();
 
-        let result = registry.execute("nonexistent", serde_json::json!({}), None).await;
+        let result = registry
+            .execute("nonexistent", serde_json::json!({}), None)
+            .await;
 
         assert!(!result.success);
         assert_eq!(result.error.as_ref().unwrap().code, "COMMAND_NOT_FOUND");
@@ -747,13 +894,9 @@ mod tests {
 
     #[test]
     fn test_handoff_command() {
-        let cmd = CommandDefinition::new(
-            "stream-connect",
-            "Connect to stream",
-            vec![],
-            TestHandler,
-        )
-        .as_handoff_with_protocol("websocket");
+        let cmd =
+            CommandDefinition::new("stream-connect", "Connect to stream", vec![], TestHandler)
+                .as_handoff_with_protocol("websocket");
 
         assert!(cmd.handoff);
         assert_eq!(cmd.handoff_protocol, Some("websocket".to_string()));
@@ -764,20 +907,11 @@ mod tests {
     fn test_list_handoff_commands() {
         let mut registry = CommandRegistry::new();
 
-        let cmd1 = CommandDefinition::new(
-            "test-regular",
-            "Regular command",
-            vec![],
-            TestHandler,
-        );
+        let cmd1 = CommandDefinition::new("test-regular", "Regular command", vec![], TestHandler);
 
-        let cmd2 = CommandDefinition::new(
-            "stream-connect",
-            "Connect to stream",
-            vec![],
-            TestHandler,
-        )
-        .as_handoff_with_protocol("websocket");
+        let cmd2 =
+            CommandDefinition::new("stream-connect", "Connect to stream", vec![], TestHandler)
+                .as_handoff_with_protocol("websocket");
 
         let cmd3 = CommandDefinition::new(
             "events-subscribe",

--- a/packages/rust/src/connectors.rs
+++ b/packages/rust/src/connectors.rs
@@ -1,0 +1,141 @@
+//! Shared connector-facing types for Rust parity.
+
+use serde::{Deserialize, Serialize};
+
+/// Options for creating a GitHub issue.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueCreateOptions {
+    pub title: String,
+    pub body: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+}
+
+/// Filters for listing issues.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueFilters {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<IssueListState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+/// Issue list state filter.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum IssueListState {
+    Open,
+    Closed,
+    All,
+}
+
+/// Represents a GitHub issue.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Issue {
+    pub number: u32,
+    pub title: String,
+    pub state: IssueState,
+    pub url: String,
+}
+
+/// Issue state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum IssueState {
+    Open,
+    Closed,
+}
+
+/// Options for creating a pull request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PrCreateOptions {
+    pub title: String,
+    pub body: String,
+    pub head: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub draft: Option<bool>,
+}
+
+/// Represents a pull request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PullRequest {
+    pub number: u32,
+    pub title: String,
+    pub state: PullRequestState,
+    pub url: String,
+}
+
+/// Pull request state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum PullRequestState {
+    Open,
+    Closed,
+    Merged,
+}
+
+/// Options for a GitHub connector.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubConnectorOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub debug: Option<bool>,
+}
+
+/// Supported package managers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum PackageManager {
+    Npm,
+    Pnpm,
+}
+
+/// Options for a package manager connector.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PackageManagerConnectorOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub debug: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_issue_serialization() {
+        let issue = Issue {
+            number: 1,
+            title: "Bug".to_string(),
+            state: IssueState::Open,
+            url: "https://example.com/issues/1".to_string(),
+        };
+
+        let json = serde_json::to_string(&issue).unwrap();
+        assert!(json.contains("\"number\":1"));
+        assert!(json.contains("\"state\":\"open\""));
+    }
+
+    #[test]
+    fn test_package_manager_serialization() {
+        let json = serde_json::to_string(&PackageManager::Pnpm).unwrap();
+        assert_eq!(json, "\"pnpm\"");
+    }
+}

--- a/packages/rust/src/errors.rs
+++ b/packages/rust/src/errors.rs
@@ -5,6 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt::Display;
 
 /// Standard error structure for command failures.
 ///
@@ -171,7 +172,10 @@ impl CommandError {
     /// Create a timeout error.
     pub fn timeout(operation_name: &str, timeout_ms: u64) -> Self {
         let mut details = HashMap::new();
-        details.insert("operationName".to_string(), serde_json::json!(operation_name));
+        details.insert(
+            "operationName".to_string(),
+            serde_json::json!(operation_name),
+        );
         details.insert("timeoutMs".to_string(), serde_json::json!(timeout_ms));
 
         Self {
@@ -246,6 +250,9 @@ pub mod error_codes {
     pub const COMMAND_CANCELLED: &str = "COMMAND_CANCELLED";
 }
 
+/// Standard error code alias for parity with other AFD implementations.
+pub type ErrorCode = String;
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // ERROR FACTORY FUNCTIONS
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -256,7 +263,10 @@ pub fn create_error(code: &str, message: &str) -> CommandError {
 }
 
 /// Create a validation error.
-pub fn validation_error(message: &str, details: Option<HashMap<String, serde_json::Value>>) -> CommandError {
+pub fn validation_error(
+    message: &str,
+    details: Option<HashMap<String, serde_json::Value>>,
+) -> CommandError {
     CommandError {
         code: error_codes::VALIDATION_ERROR.to_string(),
         message: message.to_string(),
@@ -285,6 +295,11 @@ pub fn timeout_error(operation_name: &str, timeout_ms: u64) -> CommandError {
 /// Create an internal error.
 pub fn internal_error(message: &str) -> CommandError {
     CommandError::internal(message)
+}
+
+/// Wrap an arbitrary error-like value in a CommandError.
+pub fn wrap_error(error: impl Display) -> CommandError {
+    CommandError::internal(&error.to_string())
 }
 
 /// Type guard to check if a value is a CommandError.
@@ -328,7 +343,7 @@ mod tests {
     fn test_json_serialization() {
         let error = CommandError::not_found("Item", "abc");
         let json = serde_json::to_string(&error).unwrap();
-        
+
         // Verify camelCase serialization
         assert!(json.contains("\"code\":\"NOT_FOUND\""));
         assert!(json.contains("\"resourceType\""));
@@ -340,9 +355,16 @@ mod tests {
         let error = CommandError::new("CUSTOM_ERROR", "Something went wrong")
             .with_suggestion("Try again later")
             .with_retryable(true);
-        
+
         assert_eq!(error.code, "CUSTOM_ERROR");
         assert_eq!(error.suggestion, Some("Try again later".to_string()));
         assert_eq!(error.retryable, Some(true));
+    }
+
+    #[test]
+    fn test_wrap_error() {
+        let error = wrap_error("unexpected failure");
+        assert_eq!(error.code, "INTERNAL_ERROR");
+        assert_eq!(error.message, "unexpected failure");
     }
 }

--- a/packages/rust/src/handoff.rs
+++ b/packages/rust/src/handoff.rs
@@ -270,6 +270,49 @@ pub struct HandoffResult {
     pub metadata: Option<HandoffMetadata>,
 }
 
+/// Options for creating a handoff with sensible defaults applied.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateHandoffOptions {
+    /// Protocol type for client dispatch.
+    pub protocol: HandoffProtocol,
+
+    /// Full URL to connect to.
+    pub endpoint: String,
+
+    /// Authentication credentials for the handoff.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<HandoffCredentials>,
+
+    /// Metadata for client decision-making.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HandoffMetadata>,
+}
+
+impl CreateHandoffOptions {
+    /// Create a new set of handoff options.
+    pub fn new(protocol: HandoffProtocol, endpoint: impl Into<String>) -> Self {
+        Self {
+            protocol,
+            endpoint: endpoint.into(),
+            credentials: None,
+            metadata: None,
+        }
+    }
+
+    /// Set handoff credentials.
+    pub fn with_credentials(mut self, credentials: HandoffCredentials) -> Self {
+        self.credentials = Some(credentials);
+        self
+    }
+
+    /// Set handoff metadata.
+    pub fn with_metadata(mut self, metadata: HandoffMetadata) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+}
+
 impl HandoffResult {
     /// Create a new handoff result.
     pub fn new(protocol: HandoffProtocol, endpoint: impl Into<String>) -> Self {
@@ -411,6 +454,48 @@ pub fn get_handoff_ttl(handoff: &HandoffResult) -> Option<u64> {
     }
 }
 
+/// Return the default reconnect policy.
+pub fn default_reconnect_policy() -> ReconnectPolicy {
+    ReconnectPolicy::default()
+}
+
+/// Create a handoff result with reconnect defaults applied.
+pub fn create_handoff(options: CreateHandoffOptions) -> HandoffResult {
+    let metadata = match options.metadata {
+        Some(mut metadata) => {
+            if metadata.reconnect.is_none() {
+                metadata.reconnect = Some(default_reconnect_policy());
+            }
+            Some(metadata)
+        }
+        None => Some(HandoffMetadata::new().with_reconnect(default_reconnect_policy())),
+    };
+
+    HandoffResult {
+        protocol: options.protocol,
+        endpoint: options.endpoint,
+        credentials: options.credentials,
+        metadata,
+    }
+}
+
+/// Check if a value is a reconnect policy.
+pub fn is_reconnect_policy<T: Serialize>(value: &T) -> bool {
+    if let Ok(json) = serde_json::to_value(value) {
+        matches!(json.get("allowed"), Some(serde_json::Value::Bool(_)))
+            && json
+                .get("maxAttempts")
+                .map(|value| value.is_number())
+                .unwrap_or(true)
+            && json
+                .get("backoffMs")
+                .map(|value| value.is_number())
+                .unwrap_or(true)
+    } else {
+        false
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // TESTS
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -492,6 +577,62 @@ mod tests {
 
         let no_reconnect = ReconnectPolicy::no_reconnect();
         assert!(!no_reconnect.allowed);
+    }
+
+    #[test]
+    fn test_default_reconnect_policy() {
+        let policy = default_reconnect_policy();
+        assert!(policy.allowed);
+        assert_eq!(policy.max_attempts, Some(3));
+        assert_eq!(policy.backoff_ms, Some(1000));
+    }
+
+    #[test]
+    fn test_is_reconnect_policy() {
+        assert!(is_reconnect_policy(&ReconnectPolicy::new(true)));
+
+        let valid = serde_json::json!({
+            "allowed": true,
+            "maxAttempts": 5,
+            "backoffMs": 2000
+        });
+        assert!(is_reconnect_policy(&valid));
+
+        let invalid = serde_json::json!({
+            "allowed": "true",
+            "maxAttempts": 5
+        });
+        assert!(!is_reconnect_policy(&invalid));
+    }
+
+    #[test]
+    fn test_create_handoff_applies_default_reconnect_policy() {
+        let handoff = create_handoff(CreateHandoffOptions::new(
+            HandoffProtocol::Websocket,
+            "wss://example.com/chat",
+        ));
+
+        assert_eq!(handoff.protocol, HandoffProtocol::Websocket);
+        assert_eq!(handoff.endpoint, "wss://example.com/chat");
+        assert_eq!(
+            handoff.metadata.and_then(|metadata| metadata.reconnect),
+            Some(default_reconnect_policy())
+        );
+    }
+
+    #[test]
+    fn test_create_handoff_preserves_explicit_reconnect_policy() {
+        let handoff = create_handoff(
+            CreateHandoffOptions::new(HandoffProtocol::Sse, "https://api.example.com/events")
+                .with_metadata(
+                    HandoffMetadata::new().with_reconnect(ReconnectPolicy::no_reconnect()),
+                ),
+        );
+
+        assert_eq!(
+            handoff.metadata.and_then(|metadata| metadata.reconnect),
+            Some(ReconnectPolicy::no_reconnect())
+        );
     }
 
     #[test]

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -38,12 +38,14 @@
 pub mod batch;
 pub mod bootstrap;
 pub mod commands;
+pub mod connectors;
 pub mod errors;
 pub mod handoff;
 pub mod mcp;
 pub mod metadata;
 pub mod pipeline;
 pub mod result;
+pub mod similarity;
 pub mod streaming;
 pub mod telemetry;
 
@@ -83,6 +85,15 @@ pub use commands::{
     CommandContext, CommandDefinition, CommandExample, CommandHandler, CommandMiddleware,
     CommandParameter, CommandRegistry, ExecutionTime, ExposeOptions, JsonSchema, JsonSchemaType,
     McpInputSchema, McpTool,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RE-EXPORTS: Connector types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+pub use connectors::{
+    GitHubConnectorOptions, Issue, IssueCreateOptions, IssueFilters, PackageManager,
+    PackageManagerConnectorOptions, PrCreateOptions, PullRequest,
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -127,11 +138,16 @@ pub use streaming::{
 pub use pipeline::{
     aggregate_pipeline_alternatives, aggregate_pipeline_confidence, aggregate_pipeline_reasoning,
     aggregate_pipeline_sources, aggregate_pipeline_warnings, build_confidence_breakdown,
-    create_pipeline, evaluate_condition, get_nested_value, is_pipeline_request, is_pipeline_result,
-    is_pipeline_step, resolve_variable, resolve_variables, PipelineAlternative, PipelineCondition,
-    PipelineContext, PipelineMetadata, PipelineOptions, PipelineRequest, PipelineResult,
-    PipelineSource, PipelineStep, PipelineWarning, StepConfidence, StepMetadata, StepReasoning,
-    StepResult, StepStatus,
+    create_pipeline, evaluate_condition, execute_pipeline, get_nested_value, is_and_condition,
+    is_eq_condition, is_exists_condition, is_gt_condition, is_gte_condition, is_lt_condition,
+    is_lte_condition, is_ne_condition, is_not_condition, is_or_condition, is_pipeline_condition,
+    is_pipeline_request, is_pipeline_result, is_pipeline_step, resolve_reference, resolve_variable,
+    resolve_variables, CommandExecutor, PipelineAlternative, PipelineCondition,
+    PipelineConditionAnd, PipelineConditionEq, PipelineConditionExists, PipelineConditionGt,
+    PipelineConditionGte, PipelineConditionLt, PipelineConditionLte, PipelineConditionNe,
+    PipelineConditionNot, PipelineConditionOr, PipelineContext, PipelineMetadata, PipelineOptions,
+    PipelineRequest, PipelineResult, PipelineSource, PipelineStep, PipelineWarning, StepConfidence,
+    StepMetadata, StepReasoning, StepResult, StepStatus,
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -160,6 +176,12 @@ pub use handoff::{
 // ═══════════════════════════════════════════════════════════════════════════════
 
 pub use telemetry::{create_telemetry_event, is_telemetry_event, TelemetryEvent, TelemetrySink};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RE-EXPORTS: Similarity helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+pub use similarity::{calculate_similarity, find_similar_tools};
 
 /// Crate version.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -40,17 +40,19 @@ pub mod bootstrap;
 pub mod commands;
 pub mod errors;
 pub mod handoff;
+pub mod mcp;
 pub mod metadata;
 pub mod pipeline;
 pub mod result;
 pub mod streaming;
+pub mod telemetry;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // RE-EXPORTS: Result types
 // ═══════════════════════════════════════════════════════════════════════════════
 
 pub use result::{
-    failure, failure_with, is_failure, is_success, success, success_with, CommandResult,
+    error, failure, failure_with, is_failure, is_success, success, success_with, CommandResult,
     FailureOptions, ResultMetadata, ResultOptions,
 };
 
@@ -60,7 +62,7 @@ pub use result::{
 
 pub use errors::{
     create_error, error_codes, internal_error, is_command_error, not_found_error, rate_limit_error,
-    timeout_error, validation_error, CommandError,
+    timeout_error, validation_error, wrap_error, CommandError, ErrorCode,
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -77,9 +79,22 @@ pub use metadata::{
 // ═══════════════════════════════════════════════════════════════════════════════
 
 pub use commands::{
-    command_to_mcp_tool, create_command_registry, CommandContext, CommandDefinition,
-    CommandHandler, CommandParameter, CommandRegistry, ExecutionTime, JsonSchema, JsonSchemaType,
+    command_to_mcp_tool, create_command_registry, default_expose, validate_command_name,
+    CommandContext, CommandDefinition, CommandExample, CommandHandler, CommandMiddleware,
+    CommandParameter, CommandRegistry, ExecutionTime, ExposeOptions, JsonSchema, JsonSchemaType,
     McpInputSchema, McpTool,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RE-EXPORTS: MCP types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+pub use mcp::{
+    create_mcp_error_response, create_mcp_request, create_mcp_response, is_mcp_notification,
+    is_mcp_request, is_mcp_response, text_content, McpClientCapabilities, McpContent, McpError,
+    McpErrorCode, McpErrorCodes, McpId, McpImageContent, McpInitializeParams, McpInitializeResult,
+    McpNotification, McpRequest, McpResourceContent, McpResponse, McpServerCapabilities,
+    McpTextContent, McpToolCallParams, McpToolCallResult, McpToolsListResult,
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -90,6 +105,7 @@ pub use batch::{
     calculate_batch_confidence, create_batch_request, create_batch_result,
     create_failed_batch_result, is_batch_command, is_batch_request, is_batch_result, BatchCommand,
     BatchCommandResult, BatchOptions, BatchRequest, BatchResult, BatchSummary, BatchTiming,
+    BatchWarning,
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -97,10 +113,11 @@ pub use batch::{
 // ═══════════════════════════════════════════════════════════════════════════════
 
 pub use streaming::{
-    collect_stream_data, create_complete_chunk, create_data_chunk, create_error_chunk,
-    create_progress_chunk, create_progress_chunk_with_steps, is_complete_chunk, is_data_chunk,
-    is_error_chunk, is_progress_chunk, is_stream_chunk, CompleteChunk, DataChunk, ErrorChunk,
-    ProgressChunk, StreamCallbacks, StreamChunk, StreamOptions,
+    collect_stream_data, consume_stream, create_complete_chunk, create_data_chunk,
+    create_error_chunk, create_progress_chunk, create_progress_chunk_with_steps,
+    create_timeout_controller, is_complete_chunk, is_data_chunk, is_error_chunk, is_progress_chunk,
+    is_stream_chunk, is_streamable_command, CompleteChunk, DataChunk, ErrorChunk, ProgressChunk,
+    StreamCallbacks, StreamChunk, StreamOptions, StreamableCommand, TimeoutController,
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -132,10 +149,17 @@ pub use bootstrap::{
 // ═══════════════════════════════════════════════════════════════════════════════
 
 pub use handoff::{
-    get_handoff_protocol, get_handoff_ttl, is_handoff, is_handoff_command, is_handoff_expired,
-    is_handoff_protocol, HandoffCommandLike, HandoffCredentials, HandoffMetadata, HandoffProtocol,
+    create_handoff, default_reconnect_policy, get_handoff_protocol, get_handoff_ttl, is_handoff,
+    is_handoff_command, is_handoff_expired, is_handoff_protocol, is_reconnect_policy,
+    CreateHandoffOptions, HandoffCommandLike, HandoffCredentials, HandoffMetadata, HandoffProtocol,
     HandoffResult, ReconnectPolicy,
 };
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RE-EXPORTS: Telemetry types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+pub use telemetry::{create_telemetry_event, is_telemetry_event, TelemetryEvent, TelemetrySink};
 
 /// Crate version.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -192,7 +216,7 @@ mod tests {
     fn test_json_serialization() {
         let result = success(serde_json::json!({"name": "test"}));
         let json = serde_json::to_string(&result).unwrap();
-        
+
         // Verify camelCase serialization
         assert!(json.contains("\"success\":true"));
     }

--- a/packages/rust/src/mcp.rs
+++ b/packages/rust/src/mcp.rs
@@ -1,0 +1,468 @@
+//! Model Context Protocol (MCP) types.
+//!
+//! MCP is a JSON-RPC based protocol used by AFD for agent tooling surfaces.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::commands::McpTool;
+
+static REQUEST_ID: AtomicU64 = AtomicU64::new(0);
+
+/// MCP JSON-RPC request/response identifier.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum McpId {
+    /// Numeric request identifier.
+    Number(u64),
+    /// String request identifier.
+    String(String),
+}
+
+impl From<u64> for McpId {
+    fn from(value: u64) -> Self {
+        Self::Number(value)
+    }
+}
+
+impl From<u32> for McpId {
+    fn from(value: u32) -> Self {
+        Self::Number(value.into())
+    }
+}
+
+impl From<i32> for McpId {
+    fn from(value: i32) -> Self {
+        Self::Number(value.max(0) as u64)
+    }
+}
+
+impl From<&str> for McpId {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_string())
+    }
+}
+
+impl From<String> for McpId {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+/// MCP JSON-RPC request format.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpRequest {
+    /// JSON-RPC version, always `2.0`.
+    pub jsonrpc: String,
+    /// Request ID for correlation.
+    pub id: McpId,
+    /// Method being called.
+    pub method: String,
+    /// Optional parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// MCP JSON-RPC response format.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpResponse {
+    /// JSON-RPC version, always `2.0`.
+    pub jsonrpc: String,
+    /// Request ID this is responding to.
+    pub id: McpId,
+    /// Result if successful.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    /// Error if failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<McpError>,
+}
+
+/// MCP error format.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpError {
+    /// Error code.
+    pub code: i32,
+    /// Human-readable error message.
+    pub message: String,
+    /// Additional error data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+/// MCP error code type alias.
+pub type McpErrorCode = i32;
+
+/// Standard MCP and JSON-RPC error codes.
+pub struct McpErrorCodes;
+
+impl McpErrorCodes {
+    pub const PARSE_ERROR: i32 = -32700;
+    pub const INVALID_REQUEST: i32 = -32600;
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    pub const INVALID_PARAMS: i32 = -32602;
+    pub const INTERNAL_ERROR: i32 = -32603;
+    pub const SERVER_NOT_INITIALIZED: i32 = -32002;
+    pub const REQUEST_CANCELLED: i32 = -32800;
+    pub const CONTENT_MODIFIED: i32 = -32801;
+}
+
+/// MCP notification format.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpNotification {
+    /// JSON-RPC version, always `2.0`.
+    pub jsonrpc: String,
+    /// Notification method.
+    pub method: String,
+    /// Optional parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// MCP tools/list response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolsListResult {
+    /// Available MCP tools.
+    pub tools: Vec<McpTool>,
+}
+
+/// MCP tools/call request params.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolCallParams {
+    /// Tool name.
+    pub name: String,
+    /// Tool arguments.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// MCP tools/call response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolCallResult {
+    /// Returned content chunks.
+    pub content: Vec<McpContent>,
+    /// Whether the result represents an error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+}
+
+/// Embedded MCP resource payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpEmbeddedResource {
+    /// Resource URI.
+    pub uri: String,
+    /// Resource MIME type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    /// Text payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Blob payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blob: Option<String>,
+}
+
+/// MCP text content.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpTextContent {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    pub text: String,
+}
+
+/// MCP image content.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpImageContent {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    pub data: String,
+    pub mime_type: String,
+}
+
+/// MCP resource content.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpResourceContent {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    pub resource: McpEmbeddedResource,
+}
+
+/// MCP content union.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum McpContent {
+    Text(McpTextContent),
+    Image(McpImageContent),
+    Resource(McpResourceContent),
+}
+
+/// Tool capability metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct McpToolsCapability {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub list_changed: Option<bool>,
+}
+
+/// Resource capability metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct McpResourcesCapability {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscribe: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub list_changed: Option<bool>,
+}
+
+/// Prompt capability metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct McpPromptsCapability {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub list_changed: Option<bool>,
+}
+
+/// Roots capability metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct McpRootsCapability {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub list_changed: Option<bool>,
+}
+
+/// MCP server capabilities.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<McpToolsCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<McpResourcesCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompts: Option<McpPromptsCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logging: Option<HashMap<String, serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// MCP client capabilities.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct McpClientCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub roots: Option<McpRootsCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sampling: Option<HashMap<String, serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// MCP peer info.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpPeerInfo {
+    pub name: String,
+    pub version: String,
+}
+
+/// MCP initialize request params.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpInitializeParams {
+    pub protocol_version: String,
+    pub capabilities: McpClientCapabilities,
+    pub client_info: McpPeerInfo,
+}
+
+/// MCP initialize response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpInitializeResult {
+    pub protocol_version: String,
+    pub capabilities: McpServerCapabilities,
+    pub server_info: McpPeerInfo,
+}
+
+/// Create an MCP request with an auto-incrementing ID.
+pub fn create_mcp_request(
+    method: &str,
+    params: Option<HashMap<String, serde_json::Value>>,
+) -> McpRequest {
+    McpRequest {
+        jsonrpc: "2.0".to_string(),
+        id: McpId::Number(REQUEST_ID.fetch_add(1, Ordering::SeqCst) + 1),
+        method: method.to_string(),
+        params,
+    }
+}
+
+/// Create an MCP success response.
+pub fn create_mcp_response(
+    id: impl Into<McpId>,
+    result: impl Into<serde_json::Value>,
+) -> McpResponse {
+    McpResponse {
+        jsonrpc: "2.0".to_string(),
+        id: id.into(),
+        result: Some(result.into()),
+        error: None,
+    }
+}
+
+/// Create an MCP error response.
+pub fn create_mcp_error_response(
+    id: impl Into<McpId>,
+    code: McpErrorCode,
+    message: &str,
+    data: Option<serde_json::Value>,
+) -> McpResponse {
+    McpResponse {
+        jsonrpc: "2.0".to_string(),
+        id: id.into(),
+        result: None,
+        error: Some(McpError {
+            code,
+            message: message.to_string(),
+            data,
+        }),
+    }
+}
+
+/// Create a text content item.
+pub fn text_content(text: &str) -> McpTextContent {
+    McpTextContent {
+        content_type: "text".to_string(),
+        text: text.to_string(),
+    }
+}
+
+/// Type guard for MCP requests.
+pub fn is_mcp_request<T: Serialize>(value: &T) -> bool {
+    if let Ok(json) = serde_json::to_value(value) {
+        json.get("jsonrpc") == Some(&serde_json::json!("2.0"))
+            && json.get("id").is_some()
+            && matches!(json.get("method"), Some(serde_json::Value::String(_)))
+    } else {
+        false
+    }
+}
+
+/// Type guard for MCP responses.
+pub fn is_mcp_response<T: Serialize>(value: &T) -> bool {
+    if let Ok(json) = serde_json::to_value(value) {
+        json.get("jsonrpc") == Some(&serde_json::json!("2.0"))
+            && json.get("id").is_some()
+            && (json.get("result").is_some() || json.get("error").is_some())
+    } else {
+        false
+    }
+}
+
+/// Type guard for MCP notifications.
+pub fn is_mcp_notification<T: Serialize>(value: &T) -> bool {
+    if let Ok(json) = serde_json::to_value(value) {
+        json.get("jsonrpc") == Some(&serde_json::json!("2.0"))
+            && matches!(json.get("method"), Some(serde_json::Value::String(_)))
+            && json.get("id").is_none()
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_mcp_request() {
+        let req1 = create_mcp_request("tools/list", None);
+        let req2 = create_mcp_request("tools/call", None);
+
+        assert_eq!(req1.jsonrpc, "2.0");
+        assert_eq!(req1.method, "tools/list");
+        assert!(matches!(req2.id, McpId::Number(_)));
+        assert_ne!(req1.id, req2.id);
+    }
+
+    #[test]
+    fn test_create_mcp_response() {
+        let res = create_mcp_response(1u32, serde_json::json!({ "data": "hello" }));
+        assert_eq!(res.jsonrpc, "2.0");
+        assert_eq!(res.id, McpId::Number(1));
+        assert_eq!(res.result, Some(serde_json::json!({ "data": "hello" })));
+        assert!(res.error.is_none());
+    }
+
+    #[test]
+    fn test_create_mcp_error_response() {
+        let res = create_mcp_error_response(
+            1u32,
+            McpErrorCodes::METHOD_NOT_FOUND,
+            "Method not found",
+            None,
+        );
+        assert_eq!(res.id, McpId::Number(1));
+        assert!(res.result.is_none());
+        assert_eq!(
+            res.error,
+            Some(McpError {
+                code: McpErrorCodes::METHOD_NOT_FOUND,
+                message: "Method not found".to_string(),
+                data: None,
+            })
+        );
+    }
+
+    #[test]
+    fn test_text_content() {
+        let content = text_content("hello world");
+        assert_eq!(content.content_type, "text");
+        assert_eq!(content.text, "hello world");
+    }
+
+    #[test]
+    fn test_is_mcp_request() {
+        assert!(is_mcp_request(
+            &serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": "test" })
+        ));
+        assert!(!is_mcp_request(
+            &serde_json::json!({ "jsonrpc": "1.0", "id": 1, "method": "test" })
+        ));
+    }
+
+    #[test]
+    fn test_is_mcp_response() {
+        assert!(is_mcp_response(
+            &serde_json::json!({ "jsonrpc": "2.0", "id": 1, "result": {} })
+        ));
+        assert!(is_mcp_response(
+            &serde_json::json!({ "jsonrpc": "2.0", "id": 1, "error": { "code": -1, "message": "err" } })
+        ));
+        assert!(!is_mcp_response(
+            &serde_json::json!({ "jsonrpc": "2.0", "id": 1 })
+        ));
+    }
+
+    #[test]
+    fn test_is_mcp_notification() {
+        assert!(is_mcp_notification(
+            &serde_json::json!({ "jsonrpc": "2.0", "method": "notify" })
+        ));
+        assert!(!is_mcp_notification(
+            &serde_json::json!({ "jsonrpc": "2.0", "id": 1, "method": "notify" })
+        ));
+    }
+}

--- a/packages/rust/src/pipeline.rs
+++ b/packages/rust/src/pipeline.rs
@@ -8,9 +8,15 @@
 //! - Error propagation with actionable suggestions
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Instant;
 
 use crate::errors::CommandError;
 use crate::metadata::{Alternative, Source, Warning};
+use crate::result::CommandResult;
 use crate::result::ResultMetadata;
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -255,6 +261,138 @@ pub enum PipelineCondition {
         #[serde(rename = "$not")]
         not: Box<PipelineCondition>,
     },
+}
+
+/// Check if a field exists in the context.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PipelineConditionExists {
+    #[serde(rename = "$exists")]
+    pub exists: String,
+}
+
+/// Check if a field equals a value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PipelineConditionEq {
+    #[serde(rename = "$eq")]
+    pub eq: (String, serde_json::Value),
+}
+
+/// Check if a field does not equal a value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PipelineConditionNe {
+    #[serde(rename = "$ne")]
+    pub ne: (String, serde_json::Value),
+}
+
+/// Check if a field is greater than a value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PipelineConditionGt {
+    #[serde(rename = "$gt")]
+    pub gt: (String, f64),
+}
+
+/// Check if a field is greater than or equal to a value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PipelineConditionGte {
+    #[serde(rename = "$gte")]
+    pub gte: (String, f64),
+}
+
+/// Check if a field is less than a value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PipelineConditionLt {
+    #[serde(rename = "$lt")]
+    pub lt: (String, f64),
+}
+
+/// Check if a field is less than or equal to a value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PipelineConditionLte {
+    #[serde(rename = "$lte")]
+    pub lte: (String, f64),
+}
+
+/// Logical AND - all conditions must be true.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PipelineConditionAnd {
+    #[serde(rename = "$and")]
+    pub and: Vec<PipelineCondition>,
+}
+
+/// Logical OR - any condition must be true.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PipelineConditionOr {
+    #[serde(rename = "$or")]
+    pub or: Vec<PipelineCondition>,
+}
+
+/// Logical NOT - negates a condition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PipelineConditionNot {
+    #[serde(rename = "$not")]
+    pub not: Box<PipelineCondition>,
+}
+
+impl From<PipelineConditionExists> for PipelineCondition {
+    fn from(value: PipelineConditionExists) -> Self {
+        Self::Exists {
+            exists: value.exists,
+        }
+    }
+}
+
+impl From<PipelineConditionEq> for PipelineCondition {
+    fn from(value: PipelineConditionEq) -> Self {
+        Self::Eq { eq: value.eq }
+    }
+}
+
+impl From<PipelineConditionNe> for PipelineCondition {
+    fn from(value: PipelineConditionNe) -> Self {
+        Self::Ne { ne: value.ne }
+    }
+}
+
+impl From<PipelineConditionGt> for PipelineCondition {
+    fn from(value: PipelineConditionGt) -> Self {
+        Self::Gt { gt: value.gt }
+    }
+}
+
+impl From<PipelineConditionGte> for PipelineCondition {
+    fn from(value: PipelineConditionGte) -> Self {
+        Self::Gte { gte: value.gte }
+    }
+}
+
+impl From<PipelineConditionLt> for PipelineCondition {
+    fn from(value: PipelineConditionLt) -> Self {
+        Self::Lt { lt: value.lt }
+    }
+}
+
+impl From<PipelineConditionLte> for PipelineCondition {
+    fn from(value: PipelineConditionLte) -> Self {
+        Self::Lte { lte: value.lte }
+    }
+}
+
+impl From<PipelineConditionAnd> for PipelineCondition {
+    fn from(value: PipelineConditionAnd) -> Self {
+        Self::And { and: value.and }
+    }
+}
+
+impl From<PipelineConditionOr> for PipelineCondition {
+    fn from(value: PipelineConditionOr) -> Self {
+        Self::Or { or: value.or }
+    }
+}
+
+impl From<PipelineConditionNot> for PipelineCondition {
+    fn from(value: PipelineConditionNot) -> Self {
+        Self::Not { not: value.not }
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -569,6 +707,17 @@ pub struct PipelineContext {
     pub steps: Vec<StepResult>,
 }
 
+/// Async command execution callback used by the pipeline executor.
+pub type CommandExecutor = Arc<
+    dyn Fn(
+            String,
+            serde_json::Value,
+            HashMap<String, serde_json::Value>,
+        ) -> Pin<Box<dyn Future<Output = CommandResult<serde_json::Value>> + Send>>
+        + Send
+        + Sync,
+>;
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // TYPE GUARDS
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -608,6 +757,81 @@ pub fn is_pipeline_result(value: &serde_json::Value) -> bool {
     false
 }
 
+/// Type guard to check if a value is a PipelineCondition.
+pub fn is_pipeline_condition(value: &serde_json::Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+
+    if obj.len() != 1 {
+        return false;
+    }
+
+    matches!(
+        obj.keys().next().map(String::as_str),
+        Some("$exists")
+            | Some("$eq")
+            | Some("$ne")
+            | Some("$gt")
+            | Some("$gte")
+            | Some("$lt")
+            | Some("$lte")
+            | Some("$and")
+            | Some("$or")
+            | Some("$not")
+    )
+}
+
+/// Type guard for `$exists` conditions.
+pub fn is_exists_condition(condition: &PipelineCondition) -> bool {
+    matches!(condition, PipelineCondition::Exists { .. })
+}
+
+/// Type guard for `$eq` conditions.
+pub fn is_eq_condition(condition: &PipelineCondition) -> bool {
+    matches!(condition, PipelineCondition::Eq { .. })
+}
+
+/// Type guard for `$ne` conditions.
+pub fn is_ne_condition(condition: &PipelineCondition) -> bool {
+    matches!(condition, PipelineCondition::Ne { .. })
+}
+
+/// Type guard for `$gt` conditions.
+pub fn is_gt_condition(condition: &PipelineCondition) -> bool {
+    matches!(condition, PipelineCondition::Gt { .. })
+}
+
+/// Type guard for `$gte` conditions.
+pub fn is_gte_condition(condition: &PipelineCondition) -> bool {
+    matches!(condition, PipelineCondition::Gte { .. })
+}
+
+/// Type guard for `$lt` conditions.
+pub fn is_lt_condition(condition: &PipelineCondition) -> bool {
+    matches!(condition, PipelineCondition::Lt { .. })
+}
+
+/// Type guard for `$lte` conditions.
+pub fn is_lte_condition(condition: &PipelineCondition) -> bool {
+    matches!(condition, PipelineCondition::Lte { .. })
+}
+
+/// Type guard for `$and` conditions.
+pub fn is_and_condition(condition: &PipelineCondition) -> bool {
+    matches!(condition, PipelineCondition::And { .. })
+}
+
+/// Type guard for `$or` conditions.
+pub fn is_or_condition(condition: &PipelineCondition) -> bool {
+    matches!(condition, PipelineCondition::Or { .. })
+}
+
+/// Type guard for `$not` conditions.
+pub fn is_not_condition(condition: &PipelineCondition) -> bool {
+    matches!(condition, PipelineCondition::Not { .. })
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // HELPER FUNCTIONS
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -622,7 +846,10 @@ pub fn is_pipeline_result(value: &serde_json::Value) -> bool {
 /// # Returns
 ///
 /// A PipelineRequest object
-pub fn create_pipeline(steps: Vec<PipelineStep>, options: Option<PipelineOptions>) -> PipelineRequest {
+pub fn create_pipeline(
+    steps: Vec<PipelineStep>,
+    options: Option<PipelineOptions>,
+) -> PipelineRequest {
     PipelineRequest {
         id: None,
         steps,
@@ -784,10 +1011,9 @@ pub fn build_confidence_breakdown(
         .iter()
         .filter(|s| s.status == StepStatus::Success)
         .map(|s| {
-            let alias = s
-                .alias
-                .clone()
-                .or_else(|| step_defs.and_then(|defs| defs.get(s.index).and_then(|d| d.alias.clone())));
+            let alias = s.alias.clone().or_else(|| {
+                step_defs.and_then(|defs| defs.get(s.index).and_then(|d| d.alias.clone()))
+            });
 
             StepConfidence {
                 step: s.index,
@@ -846,7 +1072,10 @@ pub fn resolve_variable(reference: &str, context: &PipelineContext) -> Option<se
 
     // $prev - previous step's data
     if reference == "$prev" {
-        return context.previous_result.as_ref().and_then(|r| r.data.clone());
+        return context
+            .previous_result
+            .as_ref()
+            .and_then(|r| r.data.clone());
     }
 
     // $first - first step's data
@@ -881,7 +1110,10 @@ pub fn resolve_variable(reference: &str, context: &PipelineContext) -> Option<se
             Some(idx) => &rest[..idx],
             None => rest,
         };
-        let step = context.steps.iter().find(|s| s.alias.as_deref() == Some(alias))?;
+        let step = context
+            .steps
+            .iter()
+            .find(|s| s.alias.as_deref() == Some(alias))?;
         if let Some(idx) = dot_index {
             return get_nested_value(step.data.as_ref()?, &rest[idx + 1..]);
         }
@@ -890,7 +1122,10 @@ pub fn resolve_variable(reference: &str, context: &PipelineContext) -> Option<se
 
     // $prev.field - field from previous step
     if reference.starts_with("$prev.") {
-        let data = context.previous_result.as_ref().and_then(|r| r.data.as_ref())?;
+        let data = context
+            .previous_result
+            .as_ref()
+            .and_then(|r| r.data.as_ref())?;
         return get_nested_value(data, &reference[6..]);
     }
 
@@ -907,6 +1142,11 @@ pub fn resolve_variable(reference: &str, context: &PipelineContext) -> Option<se
     }
 
     None
+}
+
+/// Alias for `resolve_variable` for backwards compatibility.
+pub fn resolve_reference(reference: &str, context: &PipelineContext) -> Option<serde_json::Value> {
+    resolve_variable(reference, context)
 }
 
 /// Resolve all variable references in an input value.
@@ -927,9 +1167,11 @@ pub fn resolve_variables(
         serde_json::Value::String(s) if s.starts_with('$') => {
             resolve_variable(s, context).unwrap_or(serde_json::Value::Null)
         }
-        serde_json::Value::Array(arr) => {
-            serde_json::Value::Array(arr.iter().map(|item| resolve_variables(item, context)).collect())
-        }
+        serde_json::Value::Array(arr) => serde_json::Value::Array(
+            arr.iter()
+                .map(|item| resolve_variables(item, context))
+                .collect(),
+        ),
         serde_json::Value::Object(obj) => {
             let mut new_obj = serde_json::Map::new();
             for (key, value) in obj {
@@ -1000,36 +1242,48 @@ pub fn evaluate_condition(condition: &PipelineCondition, context: &PipelineConte
             let value = resolve_variable(exists, context);
             value.is_some() && !value.as_ref().map(|v| v.is_null()).unwrap_or(true)
         }
-        PipelineCondition::Eq { eq: (ref_str, expected) } => {
+        PipelineCondition::Eq {
+            eq: (ref_str, expected),
+        } => {
             let value = resolve_variable(ref_str, context);
             value.as_ref() == Some(expected)
         }
-        PipelineCondition::Ne { ne: (ref_str, expected) } => {
+        PipelineCondition::Ne {
+            ne: (ref_str, expected),
+        } => {
             let value = resolve_variable(ref_str, context);
             value.as_ref() != Some(expected)
         }
-        PipelineCondition::Gt { gt: (ref_str, threshold) } => {
+        PipelineCondition::Gt {
+            gt: (ref_str, threshold),
+        } => {
             let value = resolve_variable(ref_str, context);
             value
                 .and_then(|v| v.as_f64())
                 .map(|n| n > *threshold)
                 .unwrap_or(false)
         }
-        PipelineCondition::Gte { gte: (ref_str, threshold) } => {
+        PipelineCondition::Gte {
+            gte: (ref_str, threshold),
+        } => {
             let value = resolve_variable(ref_str, context);
             value
                 .and_then(|v| v.as_f64())
                 .map(|n| n >= *threshold)
                 .unwrap_or(false)
         }
-        PipelineCondition::Lt { lt: (ref_str, threshold) } => {
+        PipelineCondition::Lt {
+            lt: (ref_str, threshold),
+        } => {
             let value = resolve_variable(ref_str, context);
             value
                 .and_then(|v| v.as_f64())
                 .map(|n| n < *threshold)
                 .unwrap_or(false)
         }
-        PipelineCondition::Lte { lte: (ref_str, threshold) } => {
+        PipelineCondition::Lte {
+            lte: (ref_str, threshold),
+        } => {
             let value = resolve_variable(ref_str, context);
             value
                 .and_then(|v| v.as_f64())
@@ -1046,6 +1300,190 @@ pub fn evaluate_condition(condition: &PipelineCondition, context: &PipelineConte
     }
 }
 
+/// Execute a pipeline of chained commands with variable resolution.
+pub async fn execute_pipeline(
+    request: &PipelineRequest,
+    execute: &CommandExecutor,
+    context: Option<HashMap<String, serde_json::Value>>,
+) -> PipelineResult<serde_json::Value> {
+    let start_time = Instant::now();
+    let pipeline_id = request
+        .id
+        .clone()
+        .unwrap_or_else(|| format!("pipeline-{}", chrono::Utc::now().timestamp_millis()));
+
+    if request.steps.is_empty() {
+        return PipelineResult {
+            data: serde_json::Value::Null,
+            metadata: PipelineMetadata {
+                confidence: 0.0,
+                confidence_breakdown: vec![],
+                reasoning: vec![],
+                warnings: vec![],
+                sources: vec![],
+                alternatives: vec![],
+                execution_time_ms: 0,
+                completed_steps: 0,
+                total_steps: 0,
+                result_metadata: None,
+            },
+            steps: vec![],
+        };
+    }
+
+    let mut pipeline_context = PipelineContext {
+        pipeline_input: context
+            .as_ref()
+            .map(|ctx| serde_json::Value::Object(ctx.clone().into_iter().collect())),
+        previous_result: None,
+        steps: vec![],
+    };
+
+    let mut step_results = Vec::new();
+    let options = request.options.clone().unwrap_or_default();
+    let base_context = context.unwrap_or_default();
+
+    for (i, step) in request.steps.iter().enumerate() {
+        let step_start = Instant::now();
+
+        if let Some(condition) = &step.when {
+            if !evaluate_condition(condition, &pipeline_context) {
+                step_results.push(StepResult {
+                    index: i,
+                    alias: step.alias.clone(),
+                    command: step.command.clone(),
+                    status: StepStatus::Skipped,
+                    data: None,
+                    error: None,
+                    execution_time_ms: 0,
+                    metadata: None,
+                });
+                continue;
+            }
+        }
+
+        let resolved_input = step
+            .input
+            .as_ref()
+            .map(|input| resolve_variables(input, &pipeline_context))
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        let mut step_context = base_context.clone();
+        step_context.insert(
+            "traceId".to_string(),
+            serde_json::json!(format!("{pipeline_id}-step-{i}")),
+        );
+
+        let result = execute(step.command.clone(), resolved_input, step_context).await;
+        let step_execution_time_ms = step_start.elapsed().as_millis() as u64;
+
+        if result.success {
+            let step_result = StepResult {
+                index: i,
+                alias: step.alias.clone(),
+                command: step.command.clone(),
+                status: StepStatus::Success,
+                data: result.data.clone(),
+                error: None,
+                execution_time_ms: step_execution_time_ms,
+                metadata: Some(StepMetadata {
+                    confidence: result.confidence,
+                    reasoning: result.reasoning.clone(),
+                    sources: result.sources.clone(),
+                    warnings: result.warnings.clone(),
+                    alternatives: result.alternatives.clone(),
+                }),
+            };
+            step_results.push(step_result.clone());
+            pipeline_context.steps.push(step_result.clone());
+            pipeline_context.previous_result = Some(step_result);
+        } else {
+            let step_result = StepResult {
+                index: i,
+                alias: step.alias.clone(),
+                command: step.command.clone(),
+                status: StepStatus::Failure,
+                data: None,
+                error: result.error.clone(),
+                execution_time_ms: step_execution_time_ms,
+                metadata: None,
+            };
+            step_results.push(step_result);
+
+            if options.continue_on_failure != Some(true) {
+                for (j, remaining_step) in request.steps.iter().enumerate().skip(i + 1) {
+                    step_results.push(StepResult {
+                        index: j,
+                        alias: remaining_step.alias.clone(),
+                        command: remaining_step.command.clone(),
+                        status: StepStatus::Skipped,
+                        data: None,
+                        error: None,
+                        execution_time_ms: 0,
+                        metadata: None,
+                    });
+                }
+                break;
+            }
+        }
+
+        if let Some(timeout_ms) = options.timeout_ms {
+            if start_time.elapsed().as_millis() as u64 > timeout_ms {
+                for (j, remaining_step) in request.steps.iter().enumerate().skip(i + 1) {
+                    step_results.push(StepResult {
+                        index: j,
+                        alias: remaining_step.alias.clone(),
+                        command: remaining_step.command.clone(),
+                        status: StepStatus::Skipped,
+                        data: None,
+                        error: Some(CommandError {
+                            code: "PIPELINE_TIMEOUT".to_string(),
+                            message: format!("Pipeline timeout exceeded ({timeout_ms}ms)"),
+                            suggestion: Some(
+                                "Increase timeoutMs or reduce the number of pipeline steps"
+                                    .to_string(),
+                            ),
+                            retryable: Some(true),
+                            details: None,
+                            cause: None,
+                        }),
+                        execution_time_ms: 0,
+                        metadata: None,
+                    });
+                }
+                break;
+            }
+        }
+    }
+
+    let final_data = step_results
+        .iter()
+        .rev()
+        .find(|step| step.status == StepStatus::Success)
+        .and_then(|step| step.data.clone())
+        .unwrap_or(serde_json::Value::Null);
+
+    PipelineResult {
+        data: final_data,
+        metadata: PipelineMetadata {
+            confidence: aggregate_pipeline_confidence(&step_results),
+            confidence_breakdown: build_confidence_breakdown(&step_results, Some(&request.steps)),
+            reasoning: aggregate_pipeline_reasoning(&step_results),
+            warnings: aggregate_pipeline_warnings(&step_results),
+            sources: aggregate_pipeline_sources(&step_results),
+            alternatives: aggregate_pipeline_alternatives(&step_results),
+            execution_time_ms: start_time.elapsed().as_millis() as u64,
+            completed_steps: step_results
+                .iter()
+                .filter(|step| step.status == StepStatus::Success)
+                .count() as u32,
+            total_steps: request.steps.len() as u32,
+            result_metadata: None,
+        },
+        steps: step_results,
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // TESTS
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1053,6 +1491,7 @@ pub fn evaluate_condition(condition: &PipelineCondition, context: &PipelineConte
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::result::{failure, success};
 
     #[test]
     fn test_pipeline_request_creation() {
@@ -1287,7 +1726,10 @@ mod tests {
         }];
 
         let user = resolve_variable("$steps.user", &context);
-        assert_eq!(user, Some(serde_json::json!({"id": 456, "email": "user@test.com"})));
+        assert_eq!(
+            user,
+            Some(serde_json::json!({"id": 456, "email": "user@test.com"}))
+        );
 
         let email = resolve_variable("$steps.user.email", &context);
         assert_eq!(email, Some(serde_json::json!("user@test.com")));
@@ -1325,10 +1767,13 @@ mod tests {
         });
 
         let resolved = resolve_variables(&input, &context);
-        assert_eq!(resolved, serde_json::json!({
-            "userId": 123,
-            "status": "active"
-        }));
+        assert_eq!(
+            resolved,
+            serde_json::json!({
+                "userId": 123,
+                "status": "active"
+            })
+        );
     }
 
     #[test]
@@ -1416,6 +1861,49 @@ mod tests {
             "steps": []
         });
         assert!(is_pipeline_result(&result));
+
+        let condition = serde_json::json!({
+            "$exists": "$prev.id"
+        });
+        assert!(is_pipeline_condition(&condition));
+    }
+
+    #[test]
+    fn test_condition_type_guards() {
+        let exists = PipelineCondition::from(PipelineConditionExists {
+            exists: "$prev.id".to_string(),
+        });
+        let eq = PipelineCondition::from(PipelineConditionEq {
+            eq: ("$prev.tier".to_string(), serde_json::json!("premium")),
+        });
+        let and = PipelineCondition::from(PipelineConditionAnd {
+            and: vec![exists.clone(), eq.clone()],
+        });
+
+        assert!(is_exists_condition(&exists));
+        assert!(is_eq_condition(&eq));
+        assert!(is_and_condition(&and));
+        assert!(!is_or_condition(&and));
+    }
+
+    #[test]
+    fn test_resolve_reference_alias() {
+        let mut context = PipelineContext::default();
+        context.previous_result = Some(StepResult {
+            index: 0,
+            alias: None,
+            command: "test".to_string(),
+            status: StepStatus::Success,
+            data: Some(serde_json::json!({"id": 123})),
+            error: None,
+            execution_time_ms: 10,
+            metadata: None,
+        });
+
+        assert_eq!(
+            resolve_reference("$prev.id", &context),
+            Some(serde_json::json!(123))
+        );
     }
 
     #[test]
@@ -1463,5 +1951,92 @@ mod tests {
         assert_eq!(warnings[0].code, "DEPRECATION");
         assert_eq!(warnings[0].step_index, 0);
         assert_eq!(warnings[0].step_alias, Some("step1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_execute_pipeline_single_step() {
+        let executor: CommandExecutor = Arc::new(|name, _input, _ctx| {
+            Box::pin(async move {
+                if name == "user-get" {
+                    success(serde_json::json!({"id": 1, "name": "Alice"}))
+                } else {
+                    failure(CommandError::new(
+                        "COMMAND_NOT_FOUND",
+                        format!("Command '{name}' not found"),
+                    ))
+                }
+            })
+        });
+
+        let result = execute_pipeline(
+            &PipelineRequest {
+                id: None,
+                steps: vec![PipelineStep {
+                    command: "user-get".to_string(),
+                    input: Some(serde_json::json!({"id": 1})),
+                    alias: None,
+                    when: None,
+                    stream: None,
+                }],
+                options: None,
+            },
+            &executor,
+            None,
+        )
+        .await;
+
+        assert_eq!(result.data, serde_json::json!({"id": 1, "name": "Alice"}));
+        assert_eq!(result.steps.len(), 1);
+        assert_eq!(result.steps[0].status, StepStatus::Success);
+    }
+
+    #[tokio::test]
+    async fn test_execute_pipeline_stops_on_failure() {
+        let executor: CommandExecutor = Arc::new(|name, _input, _ctx| {
+            Box::pin(async move {
+                match name.as_str() {
+                    "step-a" => success(serde_json::json!("a")),
+                    "step-b" => failure(CommandError::new("FAIL", "Step B failed")),
+                    _ => success(serde_json::json!("c")),
+                }
+            })
+        });
+
+        let result = execute_pipeline(
+            &PipelineRequest {
+                id: None,
+                steps: vec![
+                    PipelineStep {
+                        command: "step-a".to_string(),
+                        input: None,
+                        alias: None,
+                        when: None,
+                        stream: None,
+                    },
+                    PipelineStep {
+                        command: "step-b".to_string(),
+                        input: None,
+                        alias: None,
+                        when: None,
+                        stream: None,
+                    },
+                    PipelineStep {
+                        command: "step-c".to_string(),
+                        input: None,
+                        alias: None,
+                        when: None,
+                        stream: None,
+                    },
+                ],
+                options: None,
+            },
+            &executor,
+            None,
+        )
+        .await;
+
+        assert_eq!(result.steps[0].status, StepStatus::Success);
+        assert_eq!(result.steps[1].status, StepStatus::Failure);
+        assert_eq!(result.steps[2].status, StepStatus::Skipped);
     }
 }

--- a/packages/rust/src/result.rs
+++ b/packages/rust/src/result.rs
@@ -56,7 +56,6 @@ pub struct CommandResult<T> {
     // ═══════════════════════════════════════════════════════════════════════════
     // CORE FIELDS (Required for all commands)
     // ═══════════════════════════════════════════════════════════════════════════
-
     /// Whether the command executed successfully.
     ///
     /// - `true`: Command completed without errors, `data` contains the result
@@ -76,7 +75,6 @@ pub struct CommandResult<T> {
     // ═══════════════════════════════════════════════════════════════════════════
     // UX-ENABLING FIELDS (Recommended for good agent experiences)
     // ═══════════════════════════════════════════════════════════════════════════
-
     /// Agent's confidence in this result (0-1).
     ///
     /// Guidelines:
@@ -276,6 +274,18 @@ pub fn failure_with<T>(error: CommandError, options: FailureOptions) -> CommandR
     }
 }
 
+/// Create a failed command result from a code and message.
+pub fn error<T>(code: &str, message: &str, suggestion: Option<&str>) -> CommandResult<T> {
+    failure(CommandError {
+        code: code.to_string(),
+        message: message.to_string(),
+        suggestion: suggestion.map(ToString::to_string),
+        retryable: None,
+        details: None,
+        cause: None,
+    })
+}
+
 /// Options for creating failure results.
 #[derive(Debug, Clone, Default)]
 pub struct FailureOptions {
@@ -352,11 +362,11 @@ mod tests {
     fn test_json_serialization() {
         let result = success("hello".to_string());
         let json = serde_json::to_string(&result).unwrap();
-        
+
         // Verify camelCase serialization
         assert!(json.contains("\"success\":true"));
         assert!(json.contains("\"data\":\"hello\""));
-        
+
         // Verify None fields are omitted
         assert!(!json.contains("\"error\""));
         assert!(!json.contains("\"confidence\""));
@@ -370,8 +380,19 @@ mod tests {
             ..Default::default()
         };
         let result = success_with("data".to_string(), opts);
-        
+
         assert_eq!(result.confidence, Some(0.95));
         assert_eq!(result.reasoning, Some("Test reasoning".to_string()));
+    }
+
+    #[test]
+    fn test_error_helper() {
+        let result: CommandResult<()> = error("BAD_INPUT", "Input was invalid", Some("Try again"));
+        assert!(!result.success);
+        assert_eq!(result.error.as_ref().unwrap().code, "BAD_INPUT");
+        assert_eq!(
+            result.error.as_ref().unwrap().suggestion,
+            Some("Try again".to_string())
+        );
     }
 }

--- a/packages/rust/src/similarity.rs
+++ b/packages/rust/src/similarity.rs
@@ -1,0 +1,93 @@
+//! String similarity utilities for fuzzy matching.
+
+/// Calculate similarity between two strings using Levenshtein distance.
+/// Returns a value between 0 and 1.
+pub fn calculate_similarity(a: &str, b: &str) -> f64 {
+    let a_lower = a.to_lowercase();
+    let b_lower = b.to_lowercase();
+
+    if a_lower == b_lower {
+        return 1.0;
+    }
+
+    let a_chars: Vec<char> = a_lower.chars().collect();
+    let b_chars: Vec<char> = b_lower.chars().collect();
+
+    let mut matrix = vec![vec![0usize; b_chars.len() + 1]; a_chars.len() + 1];
+
+    for (i, row) in matrix.iter_mut().enumerate() {
+        row[0] = i;
+    }
+
+    for j in 0..=b_chars.len() {
+        matrix[0][j] = j;
+    }
+
+    for i in 1..=a_chars.len() {
+        for j in 1..=b_chars.len() {
+            let cost = usize::from(a_chars[i - 1] != b_chars[j - 1]);
+            matrix[i][j] = (matrix[i - 1][j] + 1)
+                .min(matrix[i][j - 1] + 1)
+                .min(matrix[i - 1][j - 1] + cost);
+        }
+    }
+
+    let max_len = a_chars.len().max(b_chars.len());
+    let distance = matrix[a_chars.len()][b_chars.len()];
+
+    if max_len == 0 {
+        1.0
+    } else {
+        1.0 - (distance as f64 / max_len as f64)
+    }
+}
+
+/// Find similar tool names for suggestions.
+pub fn find_similar_tools(
+    requested_tool: &str,
+    available_tools: &[String],
+    max_suggestions: Option<usize>,
+) -> Vec<String> {
+    let max_suggestions = max_suggestions.unwrap_or(3);
+    let mut scored: Vec<(String, f64)> = available_tools
+        .iter()
+        .map(|tool| (tool.clone(), calculate_similarity(requested_tool, tool)))
+        .filter(|(_, similarity)| *similarity >= 0.4)
+        .collect();
+
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored
+        .into_iter()
+        .take(max_suggestions)
+        .map(|(tool, _)| tool)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_similarity() {
+        assert_eq!(calculate_similarity("hello", "hello"), 1.0);
+        assert_eq!(calculate_similarity("Hello", "hello"), 1.0);
+        assert!(calculate_similarity("abc", "xyz") < 0.4);
+        assert_eq!(calculate_similarity("", ""), 1.0);
+        assert_eq!(calculate_similarity("hello", ""), 0.0);
+    }
+
+    #[test]
+    fn test_find_similar_tools() {
+        let tools = vec![
+            "todo-create".to_string(),
+            "todo-list".to_string(),
+            "user-get".to_string(),
+        ];
+
+        let suggestions = find_similar_tools("todo-crate", &tools, None);
+        assert_eq!(suggestions[0], "todo-create");
+
+        let none = find_similar_tools("zzzzzzz", &tools, None);
+        assert!(none.is_empty());
+    }
+}

--- a/packages/rust/src/streaming.rs
+++ b/packages/rust/src/streaming.rs
@@ -4,6 +4,7 @@
 //! before the final result is ready.
 
 use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
 
 use crate::errors::CommandError;
 
@@ -176,6 +177,58 @@ impl<T> Default for StreamCallbacks<T> {
     }
 }
 
+/// Marker metadata for commands that support streaming.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct StreamableCommand {
+    /// Indicates this command supports streaming responses.
+    pub streamable: bool,
+
+    /// Type of data emitted in stream chunks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_data_type: Option<String>,
+
+    /// Whether progress updates are emitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub emits_progress: Option<bool>,
+
+    /// Estimated items-per-second throughput.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub estimated_throughput: Option<f64>,
+}
+
+/// Simple timeout tracker for streaming operations.
+#[derive(Debug, Clone)]
+pub struct TimeoutController {
+    started_at: Instant,
+    timeout: Duration,
+}
+
+impl TimeoutController {
+    /// Create a new timeout controller.
+    pub fn new(timeout_ms: u64) -> Self {
+        Self {
+            started_at: Instant::now(),
+            timeout: Duration::from_millis(timeout_ms),
+        }
+    }
+
+    /// Return the elapsed time since the controller started.
+    pub fn elapsed(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+
+    /// Return the remaining time before expiry, if any.
+    pub fn remaining(&self) -> Option<Duration> {
+        self.timeout.checked_sub(self.elapsed())
+    }
+
+    /// Check whether the timeout has elapsed.
+    pub fn is_expired(&self) -> bool {
+        self.elapsed() >= self.timeout
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // FACTORY FUNCTIONS
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -285,9 +338,75 @@ pub fn is_stream_chunk<T: Serialize>(value: &T) -> bool {
         || is_error_chunk(value)
 }
 
+/// Check if a value is a streamable command marker.
+pub fn is_streamable_command<T: Serialize>(value: &T) -> bool {
+    if let Ok(json) = serde_json::to_value(value) {
+        json.get("streamable") == Some(&serde_json::json!(true))
+    } else {
+        false
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // STREAM UTILITIES
 // ═══════════════════════════════════════════════════════════════════════════════
+
+/// Consume a stream and fan out events to callbacks.
+pub async fn consume_stream<T, I>(
+    stream: I,
+    callbacks: &StreamCallbacks<T>,
+) -> Result<CompleteChunk<T>, ErrorChunk>
+where
+    I: IntoIterator<Item = StreamChunk<T>>,
+{
+    for chunk in stream {
+        match chunk {
+            StreamChunk::Progress(progress) => {
+                if let Some(callback) = &callbacks.on_progress {
+                    callback(&progress);
+                }
+            }
+            StreamChunk::Data(data) => {
+                if let Some(callback) = &callbacks.on_data {
+                    callback(&data);
+                }
+            }
+            StreamChunk::Complete(complete) => {
+                if let Some(callback) = &callbacks.on_complete {
+                    callback(&complete);
+                }
+                return Ok(complete);
+            }
+            StreamChunk::Error(error) => {
+                if let Some(callback) = &callbacks.on_error {
+                    callback(&error);
+                }
+                return Err(error);
+            }
+        }
+    }
+
+    let error = create_error_chunk(
+        CommandError::new(
+            "STREAM_ENDED_UNEXPECTEDLY",
+            "Stream ended without completion or error signal",
+        )
+        .with_suggestion("This may indicate a connection issue. Try again.")
+        .with_retryable(true),
+        true,
+    );
+
+    if let Some(callback) = &callbacks.on_error {
+        callback(&error);
+    }
+
+    Err(error)
+}
+
+/// Create a timeout controller for stream operations.
+pub fn create_timeout_controller(timeout_ms: u64) -> TimeoutController {
+    TimeoutController::new(timeout_ms)
+}
 
 /// Collect all data chunks from a stream into a single result.
 pub fn collect_stream_data<T: Clone>(chunks: &[StreamChunk<T>]) -> Vec<T> {
@@ -304,6 +423,8 @@ pub fn collect_stream_data<T: Clone>(chunks: &[StreamChunk<T>]) -> Vec<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
 
     #[test]
     fn test_progress_chunk() {
@@ -367,6 +488,20 @@ mod tests {
     }
 
     #[test]
+    fn test_is_streamable_command() {
+        let streamable = StreamableCommand {
+            streamable: true,
+            stream_data_type: Some("todo".to_string()),
+            emits_progress: Some(true),
+            estimated_throughput: None,
+        };
+        assert!(is_streamable_command(&streamable));
+
+        let not_streamable = serde_json::json!({ "streamable": false });
+        assert!(!is_streamable_command(&not_streamable));
+    }
+
+    #[test]
     fn test_collect_stream_data() {
         let chunks: Vec<StreamChunk<String>> = vec![
             StreamChunk::Progress(create_progress_chunk(25.0, "Starting")),
@@ -378,5 +513,53 @@ mod tests {
 
         let data = collect_stream_data(&chunks);
         assert_eq!(data, vec!["chunk1", "chunk2", "final"]);
+    }
+
+    #[tokio::test]
+    async fn test_consume_stream_returns_complete_chunk() {
+        let progress_seen = Arc::new(Mutex::new(0usize));
+        let data_seen = Arc::new(Mutex::new(0usize));
+
+        let callbacks = StreamCallbacks {
+            on_progress: {
+                let progress_seen = Arc::clone(&progress_seen);
+                Some(Box::new(move |_| {
+                    *progress_seen.lock().unwrap() += 1;
+                }))
+            },
+            on_data: {
+                let data_seen = Arc::clone(&data_seen);
+                Some(Box::new(move |_| {
+                    *data_seen.lock().unwrap() += 1;
+                }))
+            },
+            on_complete: None,
+            on_error: None,
+        };
+
+        let chunks = vec![
+            StreamChunk::Progress(create_progress_chunk(10.0, "Starting")),
+            StreamChunk::Data(create_data_chunk("partial".to_string(), false)),
+            StreamChunk::Complete(create_complete_chunk("done".to_string(), Some(50))),
+        ];
+
+        let result = consume_stream(chunks, &callbacks)
+            .await
+            .expect("stream should complete");
+        assert_eq!(result.data, "done");
+        assert_eq!(*progress_seen.lock().unwrap(), 1);
+        assert_eq!(*data_seen.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_timeout_controller() {
+        let controller = create_timeout_controller(5);
+        assert!(!controller.is_expired());
+        assert!(controller.remaining().is_some());
+
+        thread::sleep(Duration::from_millis(10));
+
+        assert!(controller.is_expired());
+        assert!(controller.remaining().is_none());
     }
 }

--- a/packages/rust/src/telemetry.rs
+++ b/packages/rust/src/telemetry.rs
@@ -1,0 +1,232 @@
+//! Telemetry types for AFD command execution tracking.
+//!
+//! This module provides simple event and sink primitives for recording
+//! command execution outcomes across AFD applications.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::errors::CommandError;
+
+/// Telemetry event representing a single command execution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TelemetryEvent {
+    /// Name of the command that was executed.
+    pub command_name: String,
+
+    /// ISO timestamp when command execution started.
+    pub started_at: String,
+
+    /// ISO timestamp when command execution completed.
+    pub completed_at: String,
+
+    /// Duration of execution in milliseconds.
+    pub duration_ms: u64,
+
+    /// Whether the command executed successfully.
+    pub success: bool,
+
+    /// Error details if the command failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<CommandError>,
+
+    /// Trace ID for correlating related events.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+
+    /// Confidence score from the result, if provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+
+    /// Additional metadata from the command result.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
+
+    /// Input provided to the command.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<serde_json::Value>,
+
+    /// Command version that was executed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_version: Option<String>,
+}
+
+impl TelemetryEvent {
+    /// Create a telemetry event with computed duration.
+    pub fn new(
+        command_name: impl Into<String>,
+        started_at: impl Into<String>,
+        completed_at: impl Into<String>,
+        success: bool,
+    ) -> Self {
+        let started_at = started_at.into();
+        let completed_at = completed_at.into();
+
+        Self {
+            command_name: command_name.into(),
+            duration_ms: calculate_duration_ms(&started_at, &completed_at),
+            started_at,
+            completed_at,
+            success,
+            error: None,
+            trace_id: None,
+            confidence: None,
+            metadata: None,
+            input: None,
+            command_version: None,
+        }
+    }
+
+    /// Override the duration in milliseconds.
+    pub fn with_duration_ms(mut self, duration_ms: u64) -> Self {
+        self.duration_ms = duration_ms;
+        self
+    }
+
+    /// Attach an execution error.
+    pub fn with_error(mut self, error: CommandError) -> Self {
+        self.error = Some(error);
+        self
+    }
+
+    /// Attach a trace ID.
+    pub fn with_trace_id(mut self, trace_id: impl Into<String>) -> Self {
+        self.trace_id = Some(trace_id.into());
+        self
+    }
+
+    /// Attach a confidence score.
+    pub fn with_confidence(mut self, confidence: f64) -> Self {
+        self.confidence = Some(confidence);
+        self
+    }
+
+    /// Attach metadata.
+    pub fn with_metadata(mut self, metadata: HashMap<String, serde_json::Value>) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+
+    /// Attach the command input payload.
+    pub fn with_input(mut self, input: serde_json::Value) -> Self {
+        self.input = Some(input);
+        self
+    }
+
+    /// Attach the command version.
+    pub fn with_command_version(mut self, command_version: impl Into<String>) -> Self {
+        self.command_version = Some(command_version.into());
+        self
+    }
+}
+
+/// Pluggable telemetry storage backend.
+pub trait TelemetrySink: Send + Sync {
+    /// Record a telemetry event.
+    fn record(&self, event: &TelemetryEvent);
+
+    /// Flush any buffered telemetry.
+    fn flush(&self) {}
+}
+
+/// Create a telemetry event with computed duration.
+pub fn create_telemetry_event(
+    command_name: impl Into<String>,
+    started_at: impl Into<String>,
+    completed_at: impl Into<String>,
+    success: bool,
+) -> TelemetryEvent {
+    TelemetryEvent::new(command_name, started_at, completed_at, success)
+}
+
+/// Type guard to check if a value is a telemetry event.
+pub fn is_telemetry_event<T: Serialize>(value: &T) -> bool {
+    if let Ok(json) = serde_json::to_value(value) {
+        matches!(json.get("commandName"), Some(serde_json::Value::String(_)))
+            && matches!(json.get("startedAt"), Some(serde_json::Value::String(_)))
+            && matches!(json.get("completedAt"), Some(serde_json::Value::String(_)))
+            && matches!(json.get("durationMs"), Some(serde_json::Value::Number(_)))
+            && matches!(json.get("success"), Some(serde_json::Value::Bool(_)))
+    } else {
+        false
+    }
+}
+
+fn calculate_duration_ms(started_at: &str, completed_at: &str) -> u64 {
+    let started = chrono::DateTime::parse_from_rfc3339(started_at).ok();
+    let completed = chrono::DateTime::parse_from_rfc3339(completed_at).ok();
+
+    match (started, completed) {
+        (Some(started), Some(completed)) => {
+            let duration_ms = completed.timestamp_millis() - started.timestamp_millis();
+            duration_ms.max(0) as u64
+        }
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_telemetry_event() {
+        let event = create_telemetry_event(
+            "todo-create",
+            "2024-01-15T10:30:00.000Z",
+            "2024-01-15T10:30:00.150Z",
+            true,
+        );
+
+        assert_eq!(event.command_name, "todo-create");
+        assert_eq!(event.duration_ms, 150);
+        assert!(event.success);
+    }
+
+    #[test]
+    fn test_create_telemetry_event_with_optional_fields() {
+        let mut metadata = HashMap::new();
+        metadata.insert("region".to_string(), serde_json::json!("us-east"));
+
+        let event = create_telemetry_event(
+            "todo-create",
+            "2024-01-15T10:30:00.000Z",
+            "2024-01-15T10:30:00.150Z",
+            false,
+        )
+        .with_duration_ms(200)
+        .with_error(CommandError::new("NOT_FOUND", "Item not found"))
+        .with_trace_id("trace-123")
+        .with_confidence(0.95)
+        .with_metadata(metadata.clone())
+        .with_input(serde_json::json!({"title": "Test"}))
+        .with_command_version("1.0.0");
+
+        assert_eq!(event.duration_ms, 200);
+        assert_eq!(event.trace_id, Some("trace-123".to_string()));
+        assert_eq!(event.confidence, Some(0.95));
+        assert_eq!(event.metadata, Some(metadata));
+        assert_eq!(event.command_version, Some("1.0.0".to_string()));
+    }
+
+    #[test]
+    fn test_is_telemetry_event() {
+        let event = create_telemetry_event(
+            "todo-create",
+            "2024-01-15T10:30:00.000Z",
+            "2024-01-15T10:30:00.150Z",
+            true,
+        );
+        assert!(is_telemetry_event(&event));
+
+        let invalid = serde_json::json!({
+            "commandName": "todo-create",
+            "startedAt": "2024-01-15T10:30:00.000Z",
+            "completedAt": "2024-01-15T10:30:00.150Z",
+            "durationMs": "150",
+            "success": true
+        });
+        assert!(!is_telemetry_event(&invalid));
+    }
+}


### PR DESCRIPTION
## Summary
- complete the remaining Rust export parity work across MCP, pipeline, connectors, similarity, and helper surfaces
- add the active rust parity tracking doc and move the finished PyPI publishing proposal to complete
- refresh the `afd-rust` skill examples so they match the current Rust crate APIs and patterns

## Verification
- cargo test
- uv run --project alfred alfred parity --path .
- git push (pre-push hooks: file-size, lint-all, orphan-files, portability, test, typecheck)

## Notes
- parity now reports `missing_from_rust: []`
- Rust skills were checked repo-wide; only `.claude/skills/afd-rust/SKILL.md` needed updates